### PR TITLE
feat: add UniFi Protect API (protect feature)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,6 @@ jobs:
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo build --locked --verbose --all-targets
       - run: cargo test --locked --verbose
+      - run: cargo build --locked --verbose --no-default-features
+      - run: cargo test --locked --verbose --no-default-features --features protect
+      - run: cargo test --locked --verbose --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,6 +1105,7 @@ dependencies = [
  "chrono",
  "futures",
  "native-tls",
+ "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 url = "2.5"
+percent-encoding = "2.3"
 futures = "0.3"
 tokio-tungstenite = { version = "0.26", features = ["native-tls"], optional = true }
 native-tls = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,11 @@ exclude = [
     "sailr.json",
 ]
 
+[features]
+default = ["unifi"]
+unifi = []
+protect = ["dep:tokio-tungstenite", "dep:native-tls"]
+
 [dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 reqwest = { version = "0.12", features = ["cookies", "json"] }
@@ -26,6 +31,12 @@ serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 url = "2.5"
 futures = "0.3"
+tokio-tungstenite = { version = "0.26", features = ["native-tls"], optional = true }
+native-tls = { version = "0.2", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["test-util"] }
+wiremock = "0.6"
+
+[package.metadata.docs.rs]
+all-features = true

--- a/README.md
+++ b/README.md
@@ -106,7 +106,14 @@ ends on disconnect and there is no replay cursor, so reconnect in a loop:
 use futures::StreamExt;
 
 loop {
-    let mut stream = client.subscribe_events().await?;
+    let mut stream = match client.subscribe_events().await {
+        Ok(stream) => stream,
+        Err(e) => {
+            eprintln!("subscription failed: {e}");
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            continue;
+        }
+    };
     while let Some(msg) = stream.next().await {
         match msg {
             Ok(event) => println!("{:?} {:?}", event.action, event.item.event_type),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # rustifi
 
-A Rust API library for UniFi Network controllers.
+A Rust API library for UniFi Network controllers, with optional support for
+the UniFi Protect Integration API.
 
 ## Quick Start
 
@@ -52,6 +53,74 @@ let client = UnifiClient::with_api_key_insecure("https://192.168.1.1", "api-key"
 > **Security Warning**: The `_insecure` methods disable TLS certificate validation,
 > which makes connections vulnerable to man-in-the-middle attacks. Only use these
 > methods for local controllers on trusted networks.
+
+## Cargo Features
+
+- `unifi` *(default)* — the UniFi Network controller API (`UnifiClient`).
+- `protect` — the official UniFi Protect Integration API (`ProtectClient`).
+
+```toml
+# Network only (default)
+rustifi = "2"
+
+# Network + Protect
+rustifi = { version = "2", features = ["protect"] }
+
+# Protect only
+rustifi = { version = "2", default-features = false, features = ["protect"] }
+```
+
+## UniFi Protect
+
+The `protect` feature wraps the official Protect Integration API (Protect >= 5.3),
+served at `https://{console}/proxy/protect/integration/v1`. Generate an API key in
+the Protect app under **Settings -> Control Plane -> Integrations**.
+
+```rust
+use rustifi::protect::ProtectClient;
+
+#[tokio::main]
+async fn main() -> rustifi::Result<()> {
+    // Local consoles usually have self-signed certificates, so the
+    // `_insecure` constructor is common here (trusted networks only).
+    let client = ProtectClient::new_insecure("https://192.168.1.1", "your-api-key")?;
+
+    // List cameras and save a snapshot
+    for camera in client.cameras().await? {
+        println!("Camera: {} ({:?})", camera.name, camera.state);
+    }
+    let jpeg = client.snapshot("camera-id", true).await?;
+    std::fs::write("snapshot.jpg", jpeg)?;
+
+    Ok(())
+}
+```
+
+### Live events
+
+Motion, smart-detection, doorbell, and connectivity events are delivered over a
+WebSocket (the Integration API has no REST event-history endpoint). The stream
+ends on disconnect and there is no replay cursor, so reconnect in a loop:
+
+```rust
+use futures::StreamExt;
+
+loop {
+    let mut stream = client.subscribe_events().await?;
+    while let Some(msg) = stream.next().await {
+        match msg {
+            Ok(event) => println!("{:?} {:?}", event.action, event.item.event_type),
+            Err(e) => eprintln!("stream error: {e}"),
+        }
+    }
+    // Events that occur while disconnected are lost.
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+}
+```
+
+`subscribe_device_updates()` provides the same envelope for partial device-state
+patches. Not yet covered: PTZ, talkback, liveviews, file uploads, chime play,
+and alarm-manager webhooks.
 
 ## WORK IN PROGRESS
 

--- a/examples/protect-events/Cargo.lock
+++ b/examples/protect-events/Cargo.lock
@@ -1066,6 +1066,7 @@ dependencies = [
  "chrono",
  "futures",
  "native-tls",
+ "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",

--- a/examples/protect-events/Cargo.lock
+++ b/examples/protect-events/Cargo.lock
@@ -3,31 +3,12 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "assert-json-diff"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -38,9 +19,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -50,9 +31,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -65,21 +46,21 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.53"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -93,9 +74,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -118,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "cookie_store"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
 dependencies = [
  "cookie",
  "document-features",
@@ -139,6 +120,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -176,31 +167,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
-name = "deadpool"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
-dependencies = [
- "deadpool-runtime",
- "lazy_static",
- "num_cpus",
- "tokio",
-]
-
-[[package]]
-name = "deadpool-runtime"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
-
-[[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
-dependencies = [
- "powerfmt",
-]
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "digest"
@@ -214,13 +184,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -259,15 +229,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -301,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -316,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -326,15 +296,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -343,38 +313,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -416,15 +386,26 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.13"
+name = "getrandom"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -441,21 +422,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -463,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -473,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -491,16 +466,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -510,10 +479,8 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -521,15 +488,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -553,14 +519,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -579,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -603,12 +568,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -616,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -629,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -643,15 +609,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -663,15 +629,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -695,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -705,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -715,59 +681,44 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -776,16 +727,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
-name = "log"
-version = "0.4.29"
+name = "lock_api"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
@@ -795,9 +755,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -806,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
@@ -823,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -837,32 +797,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -875,25 +824,48 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -904,27 +876,21 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -946,11 +912,20 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "protect-events"
+version = "1.0.0"
+dependencies = [
+ "futures",
+ "rustifi",
+ "tokio",
 ]
 
 [[package]]
@@ -971,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -983,6 +958,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1014,33 +995,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.13.1"
+name = "redox_syscall"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
+ "bitflags",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -1112,14 +1073,13 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "url",
- "wiremock",
 ]
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -1130,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1143,18 +1103,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1163,33 +1123,39 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "security-framework"
-version = "2.11.1"
+name = "scopeguard"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1197,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1207,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1217,29 +1183,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1273,27 +1239,37 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1313,9 +1289,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1339,17 +1326,17 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -1365,12 +1352,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1378,32 +1365,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -1413,15 +1399,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1429,9 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1439,14 +1425,16 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -1454,13 +1442,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1499,13 +1487,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -1527,20 +1516,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -1606,9 +1595,9 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "untrusted"
@@ -1669,18 +1658,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1691,23 +1680,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1715,31 +1700,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1766,7 +1751,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1777,7 +1762,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1898,45 +1883,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "wiremock"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
-dependencies = [
- "assert-json-diff",
- "base64",
- "deadpool",
- "futures",
- "http",
- "http-body-util",
- "hyper",
- "hyper-util",
- "log",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "tokio",
- "url",
-]
-
-[[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -1945,13 +1907,13 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -1972,41 +1934,41 @@ checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2015,9 +1977,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2026,17 +1988,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.15"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f63c051f4fe3c1509da62131a678643c5b6fbdc9273b2b79d4378ebda003d2"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/examples/protect-events/Cargo.toml
+++ b/examples/protect-events/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "protect-events"
+version = "1.0.0"
+edition = "2021"
+description = "Example that lists Protect cameras, saves a snapshot, and tails live events"
+
+[dependencies]
+rustifi = { path = "../..", default-features = false, features = ["protect"] }
+tokio = { version = "1", features = ["full"] }
+futures = "0.3"

--- a/examples/protect-events/src/main.rs
+++ b/examples/protect-events/src/main.rs
@@ -1,0 +1,51 @@
+use futures::StreamExt;
+use rustifi::protect::ProtectClient;
+
+#[tokio::main]
+async fn main() -> rustifi::Result<()> {
+    let base_url = std::env::var("PROTECT_URL").expect("PROTECT_URL not set");
+    let api_key = std::env::var("PROTECT_API_KEY").expect("PROTECT_API_KEY not set");
+
+    // Local consoles usually have self-signed certificates; only use the
+    // insecure constructor on trusted networks.
+    let client = ProtectClient::new_insecure(base_url, api_key)?;
+
+    let info = client.meta_info().await?;
+    println!("Protect version: {}", info.application_version);
+
+    let cameras = client.cameras().await?;
+    for camera in &cameras {
+        println!("Camera: {} [{}] ({:?})", camera.name, camera.id, camera.state);
+    }
+
+    if let Some(camera) = cameras.first() {
+        let jpeg = client.snapshot(&camera.id, false).await?;
+        let path = format!("{}.jpg", camera.id);
+        std::fs::write(&path, jpeg).expect("failed to write snapshot");
+        println!("Saved snapshot of {} to {}", camera.name, path);
+    }
+
+    println!("Tailing live events (Ctrl-C to quit)...");
+    loop {
+        let mut stream = match client.subscribe_events().await {
+            Ok(stream) => stream,
+            Err(e) => {
+                eprintln!("subscription failed: {e}; retrying in 5s");
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                continue;
+            }
+        };
+        while let Some(msg) = stream.next().await {
+            match msg {
+                Ok(event) => println!(
+                    "[{:?}] {:?} on {} (smart: {:?})",
+                    event.action, event.item.event_type, event.item.device,
+                    event.item.smart_detect_types
+                ),
+                Err(e) => eprintln!("stream error: {e}"),
+            }
+        }
+        eprintln!("disconnected; reconnecting in 5s (events in between are lost)");
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,14 +1,25 @@
+#[cfg(feature = "unifi")]
 pub mod acl;
+#[cfg(feature = "unifi")]
 pub mod clients;
+#[cfg(feature = "unifi")]
 pub mod devices;
+#[cfg(feature = "unifi")]
 pub mod dns;
 pub mod endpoint;
+#[cfg(feature = "unifi")]
 pub mod firewall;
+#[cfg(feature = "unifi")]
 pub mod hotspot;
+#[cfg(feature = "unifi")]
 pub mod networks;
+#[cfg(feature = "unifi")]
 pub mod resources;
+#[cfg(feature = "unifi")]
 pub mod sites;
+#[cfg(feature = "unifi")]
 pub mod traffic;
+#[cfg(feature = "unifi")]
 pub mod wifi;
 
 pub use endpoint::Endpoint;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
-use crate::api::endpoint::{Endpoint, HttpMethod};
+use crate::api::endpoint::Endpoint;
 use crate::error::Result;
-use reqwest::{cookie::Jar, Client};
-use std::sync::Arc;
+use crate::transport;
+use reqwest::Client;
 
 /// The base URL for the UniFi remote cloud API.
 pub const REMOTE_API_URL: &str = "https://api.ui.com";
@@ -107,23 +107,7 @@ impl UnifiClient {
         base_path: impl Into<String>,
         accept_invalid_certs: bool,
     ) -> Result<Self> {
-        let jar = Jar::default();
-        let cookie_store = Arc::new(jar);
-
-        let mut builder = Client::builder()
-            .user_agent("rustifi/1.0")
-            .cookie_store(true)
-            .cookie_provider(cookie_store)
-            .connect_timeout(std::time::Duration::from_secs(30))
-            .timeout(std::time::Duration::from_secs(60));
-
-        if accept_invalid_certs {
-            builder = builder
-                .danger_accept_invalid_certs(true)
-                .danger_accept_invalid_hostnames(true);
-        }
-
-        let http = builder.build()?;
+        let http = transport::build_http_client(accept_invalid_certs, true)?;
 
         Ok(Self {
             http,
@@ -252,21 +236,12 @@ impl UnifiClient {
     /// # Ok::<(), rustifi::Error>(())
     /// ```
     pub fn remote(api_key: impl Into<String>, host_id: impl Into<String>) -> Result<Self> {
-        let jar = Jar::default();
-        let cookie_store = Arc::new(jar);
-
         // Validate the API key can be parsed as a header value
         let key = api_key.into();
         let _: reqwest::header::HeaderValue = key.parse()?;
 
         // For remote API, we don't need to accept invalid certs
-        let http = Client::builder()
-            .user_agent("rustifi/1.0")
-            .cookie_store(true)
-            .cookie_provider(cookie_store)
-            .connect_timeout(std::time::Duration::from_secs(30))
-            .timeout(std::time::Duration::from_secs(60))
-            .build()?;
+        let http = transport::build_http_client(false, true)?;
 
         Ok(Self {
             http,
@@ -308,51 +283,20 @@ impl UnifiClient {
         E: Endpoint,
         E::Response: for<'a> serde::Deserialize<'a>,
     {
-        let path = endpoint.build_path();
-
-        // Build URL based on whether this is a remote or local client
-        let url = if let Some(host_id) = &self.host_id {
+        // Build URL prefix based on whether this is a remote or local client
+        let url_prefix = if let Some(host_id) = &self.host_id {
             // Remote API: https://api.ui.com/v1/connector/consoles/{host_id}/{path}
             format!(
-                "{}/{}/connector/consoles/{}/{}",
-                self.base_url, self.base_path, host_id, path
+                "{}/{}/connector/consoles/{}",
+                self.base_url, self.base_path, host_id
             )
         } else {
             // Local API: {base_url}/{base_path}/{path}
-            format!("{}/{}/{}", self.base_url, self.base_path, path)
+            format!("{}/{}", self.base_url, self.base_path)
         };
 
-        let mut headers = reqwest::header::HeaderMap::new();
-
-        if let Some(api_key) = &self.api_key {
-            headers.insert("X-API-Key", api_key.parse()?);
-        }
-
-        let mut request = self.http.request(E::METHOD.into(), &url).headers(headers);
-
-        // Append query parameters using reqwest's query() for proper URL encoding
-        let params = endpoint.query_params();
-        if !params.is_empty() {
-            request = request.query(&params);
-        }
-
-        // Add JSON body for POST/PUT/PATCH methods
-        if let Some(body) = endpoint.request_body()? {
-            request = request.json(&body);
-        }
-
-        let response = request.send().await?;
-
-        if !response.status().is_success() {
-            return Err(crate::error::Error::Request(
-                response.error_for_status().unwrap_err(),
-            ));
-        }
-
-        let body = response.text().await?;
-        let response_data = serde_json::from_str::<E::Response>(&body)
-            .map_err(|e| crate::error::Error::Parse(format!("{}\nResponse body: {}", e, body)))?;
-        Ok(response_data)
+        transport::execute_endpoint(&self.http, &url_prefix, self.api_key.as_deref(), endpoint)
+            .await
     }
 
     /// Execute a request for endpoints without dynamic path parameters.
@@ -371,17 +315,5 @@ impl UnifiClient {
 
     pub fn base_path(&self) -> &str {
         &self.base_path
-    }
-}
-
-impl From<HttpMethod> for reqwest::Method {
-    fn from(method: HttpMethod) -> Self {
-        match method {
-            HttpMethod::Get => reqwest::Method::GET,
-            HttpMethod::Post => reqwest::Method::POST,
-            HttpMethod::Put => reqwest::Method::PUT,
-            HttpMethod::Patch => reqwest::Method::PATCH,
-            HttpMethod::Delete => reqwest::Method::DELETE,
-        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,9 @@ pub enum Error {
     #[error("API request failed: {0}")]
     Request(#[from] reqwest::Error),
 
+    #[error("API request failed with status {status}: {body}")]
+    Api { status: u16, body: String },
+
     #[error("Response parsing failed: {0}")]
     Parse(String),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("Authentication failed: {0}")]
     Auth(String),
@@ -28,6 +29,9 @@ pub enum Error {
 
     #[error("URL parsing failed: {0}")]
     UrlParse(#[from] url::ParseError),
+
+    #[error("WebSocket error: {0}")]
+    WebSocket(String),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,27 +1,49 @@
 pub mod api;
+#[cfg(feature = "unifi")]
 pub mod client;
 pub mod error;
 pub mod models;
+#[cfg(feature = "unifi")]
 pub mod pagination;
+#[cfg(feature = "protect")]
+pub mod protect;
+#[cfg(feature = "unifi")]
 pub mod response;
+#[cfg(feature = "unifi")]
 pub mod stats;
+#[cfg(any(feature = "unifi", feature = "protect"))]
+pub(crate) mod transport;
+#[cfg(feature = "unifi")]
 pub mod wrappers;
 
+#[cfg(feature = "unifi")]
 pub use client::{UnifiClient, REMOTE_API_URL};
 pub use error::{Error, Result};
+#[cfg(feature = "unifi")]
 pub use pagination::DEFAULT_PAGE_SIZE;
+#[cfg(feature = "protect")]
+pub use protect::ProtectClient;
+#[cfg(feature = "unifi")]
 pub use stats::{aggregate_clients_by_device, get_device_client_stats, DeviceClientStats};
+#[cfg(feature = "unifi")]
 pub use wrappers::DeviceWithInfo;
 
 pub mod prelude {
+    #[cfg(feature = "unifi")]
     pub use crate::api::networks::{Network, NetworkRequest};
     pub use crate::api::Endpoint;
+    #[cfg(feature = "unifi")]
     pub use crate::client::UnifiClient;
     pub use crate::error::{Error, Result};
+    #[cfg(feature = "unifi")]
     pub use crate::models::{
         APModel, Client, Device, DeviceType, FirewallAction, FirewallPolicy, FirewallZone, Site,
         Voucher, WifiBroadcast, WifiSecurity,
     };
+    #[cfg(feature = "protect")]
+    pub use crate::protect::prelude::*;
+    #[cfg(feature = "unifi")]
     pub use crate::stats::DeviceClientStats;
+    #[cfg(feature = "unifi")]
     pub use crate::wrappers::DeviceWithInfo;
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,28 +1,48 @@
+#[cfg(feature = "unifi")]
 pub mod access_point;
+#[cfg(feature = "unifi")]
 pub mod client;
 pub mod common;
+#[cfg(feature = "unifi")]
 pub mod device;
+#[cfg(feature = "unifi")]
 pub mod device_details;
+#[cfg(feature = "unifi")]
 pub mod device_statistics;
+#[cfg(feature = "unifi")]
 pub mod firewall;
+#[cfg(feature = "unifi")]
 pub mod site;
+#[cfg(feature = "unifi")]
 pub mod site_device;
+#[cfg(feature = "unifi")]
 pub mod voucher;
+#[cfg(feature = "unifi")]
 pub mod wifi;
 
+#[cfg(feature = "unifi")]
 pub use access_point::APModel;
+#[cfg(feature = "unifi")]
 pub use client::{AccessType, Client, ClientAccess, ClientType};
 pub use common::{IpAddress, MacAddress, Timestamp};
+#[cfg(feature = "unifi")]
 pub use device::{Device, DeviceType};
+#[cfg(feature = "unifi")]
 pub use device_details::{
     AccessPointFeature, DeviceDetails, DeviceFeatures, DeviceUplink, InterfaceState,
     PhysicalInterfaces, PoE, Port, PortConnector, Radio, SwitchingFeature, WirelessStandard,
 };
+#[cfg(feature = "unifi")]
 pub use device_statistics::{
     DeviceStatistics, RadioStatistics, StatisticsInterfaces, StatisticsUplink,
 };
+#[cfg(feature = "unifi")]
 pub use firewall::{FirewallAction, FirewallPolicy, FirewallZone};
+#[cfg(feature = "unifi")]
 pub use site::Site;
+#[cfg(feature = "unifi")]
 pub use site_device::{DeviceFeature, DeviceInterface, DeviceState, SiteDevice};
+#[cfg(feature = "unifi")]
 pub use voucher::Voucher;
+#[cfg(feature = "unifi")]
 pub use wifi::{WifiBroadcast, WifiSecurity};

--- a/src/protect/api/cameras.rs
+++ b/src/protect/api/cameras.rs
@@ -34,7 +34,7 @@ impl Endpoint for GetCamera {
     type Response = Camera;
 
     fn build_path(&self) -> String {
-        format!("cameras/{}", self.camera_id)
+        format!("cameras/{}", super::encode_id(&self.camera_id))
     }
 }
 
@@ -61,7 +61,7 @@ impl Endpoint for PatchCamera {
     type Response = Camera;
 
     fn build_path(&self) -> String {
-        format!("cameras/{}", self.camera_id)
+        format!("cameras/{}", super::encode_id(&self.camera_id))
     }
 
     fn request_body(&self) -> Result<Option<Value>, serde_json::Error> {
@@ -90,7 +90,7 @@ impl Endpoint for GetRtspsStreams {
     type Response = RtspsStreams;
 
     fn build_path(&self) -> String {
-        format!("cameras/{}/rtsps-stream", self.camera_id)
+        format!("cameras/{}/rtsps-stream", super::encode_id(&self.camera_id))
     }
 }
 
@@ -117,7 +117,7 @@ impl Endpoint for CreateRtspsStream {
     type Response = RtspsStreams;
 
     fn build_path(&self) -> String {
-        format!("cameras/{}/rtsps-stream", self.camera_id)
+        format!("cameras/{}/rtsps-stream", super::encode_id(&self.camera_id))
     }
 
     fn request_body(&self) -> Result<Option<Value>, serde_json::Error> {
@@ -149,7 +149,7 @@ impl Endpoint for DeleteRtspsStream {
     type Response = Option<serde_json::Value>;
 
     fn build_path(&self) -> String {
-        format!("cameras/{}/rtsps-stream", self.camera_id)
+        format!("cameras/{}/rtsps-stream", super::encode_id(&self.camera_id))
     }
 
     fn query_params(&self) -> Vec<(&'static str, String)> {

--- a/src/protect/api/cameras.rs
+++ b/src/protect/api/cameras.rs
@@ -1,0 +1,161 @@
+use crate::api::endpoint::{Endpoint, HttpMethod};
+use crate::protect::models::{Camera, CameraPatch, RtspsQuality, RtspsStreams};
+use serde_json::Value;
+
+/// Fetch all cameras.
+/// Endpoint: GET /proxy/protect/integration/v1/cameras
+#[derive(Debug, Clone, Default)]
+pub struct GetCameras;
+
+impl Endpoint for GetCameras {
+    const PATH: &'static str = "cameras";
+    const METHOD: HttpMethod = HttpMethod::Get;
+    type Response = Vec<Camera>;
+}
+
+/// Fetch a single camera by ID.
+/// Endpoint: GET /proxy/protect/integration/v1/cameras/{id}
+#[derive(Debug, Clone)]
+pub struct GetCamera {
+    pub camera_id: String,
+}
+
+impl GetCamera {
+    pub fn new(camera_id: impl Into<String>) -> Self {
+        Self {
+            camera_id: camera_id.into(),
+        }
+    }
+}
+
+impl Endpoint for GetCamera {
+    const PATH: &'static str = "cameras/{id}";
+    const METHOD: HttpMethod = HttpMethod::Get;
+    type Response = Camera;
+
+    fn build_path(&self) -> String {
+        format!("cameras/{}", self.camera_id)
+    }
+}
+
+/// Partially update a camera's settings.
+/// Endpoint: PATCH /proxy/protect/integration/v1/cameras/{id}
+#[derive(Debug, Clone)]
+pub struct PatchCamera {
+    pub camera_id: String,
+    pub patch: CameraPatch,
+}
+
+impl PatchCamera {
+    pub fn new(camera_id: impl Into<String>, patch: CameraPatch) -> Self {
+        Self {
+            camera_id: camera_id.into(),
+            patch,
+        }
+    }
+}
+
+impl Endpoint for PatchCamera {
+    const PATH: &'static str = "cameras/{id}";
+    const METHOD: HttpMethod = HttpMethod::Patch;
+    type Response = Camera;
+
+    fn build_path(&self) -> String {
+        format!("cameras/{}", self.camera_id)
+    }
+
+    fn request_body(&self) -> Result<Option<Value>, serde_json::Error> {
+        Ok(Some(serde_json::to_value(&self.patch)?))
+    }
+}
+
+/// Fetch the currently provisioned RTSPS stream URLs for a camera.
+/// Endpoint: GET /proxy/protect/integration/v1/cameras/{id}/rtsps-stream
+#[derive(Debug, Clone)]
+pub struct GetRtspsStreams {
+    pub camera_id: String,
+}
+
+impl GetRtspsStreams {
+    pub fn new(camera_id: impl Into<String>) -> Self {
+        Self {
+            camera_id: camera_id.into(),
+        }
+    }
+}
+
+impl Endpoint for GetRtspsStreams {
+    const PATH: &'static str = "cameras/{id}/rtsps-stream";
+    const METHOD: HttpMethod = HttpMethod::Get;
+    type Response = RtspsStreams;
+
+    fn build_path(&self) -> String {
+        format!("cameras/{}/rtsps-stream", self.camera_id)
+    }
+}
+
+/// Provision RTSPS streams for the given qualities.
+/// Endpoint: POST /proxy/protect/integration/v1/cameras/{id}/rtsps-stream
+#[derive(Debug, Clone)]
+pub struct CreateRtspsStream {
+    pub camera_id: String,
+    pub qualities: Vec<RtspsQuality>,
+}
+
+impl CreateRtspsStream {
+    pub fn new(camera_id: impl Into<String>, qualities: Vec<RtspsQuality>) -> Self {
+        Self {
+            camera_id: camera_id.into(),
+            qualities,
+        }
+    }
+}
+
+impl Endpoint for CreateRtspsStream {
+    const PATH: &'static str = "cameras/{id}/rtsps-stream";
+    const METHOD: HttpMethod = HttpMethod::Post;
+    type Response = RtspsStreams;
+
+    fn build_path(&self) -> String {
+        format!("cameras/{}/rtsps-stream", self.camera_id)
+    }
+
+    fn request_body(&self) -> Result<Option<Value>, serde_json::Error> {
+        Ok(Some(serde_json::json!({ "qualities": self.qualities })))
+    }
+}
+
+/// Remove provisioned RTSPS streams for the given qualities.
+/// Endpoint: DELETE /proxy/protect/integration/v1/cameras/{id}/rtsps-stream?qualities=...
+#[derive(Debug, Clone)]
+pub struct DeleteRtspsStream {
+    pub camera_id: String,
+    pub qualities: Vec<RtspsQuality>,
+}
+
+impl DeleteRtspsStream {
+    pub fn new(camera_id: impl Into<String>, qualities: Vec<RtspsQuality>) -> Self {
+        Self {
+            camera_id: camera_id.into(),
+            qualities,
+        }
+    }
+}
+
+impl Endpoint for DeleteRtspsStream {
+    const PATH: &'static str = "cameras/{id}/rtsps-stream";
+    const METHOD: HttpMethod = HttpMethod::Delete;
+    // The console returns an empty body on success.
+    type Response = Option<serde_json::Value>;
+
+    fn build_path(&self) -> String {
+        format!("cameras/{}/rtsps-stream", self.camera_id)
+    }
+
+    fn query_params(&self) -> Vec<(&'static str, String)> {
+        self.qualities
+            .iter()
+            .map(|q| ("qualities", q.as_str().to_string()))
+            .collect()
+    }
+}

--- a/src/protect/api/chimes.rs
+++ b/src/protect/api/chimes.rs
@@ -1,0 +1,70 @@
+use crate::api::endpoint::{Endpoint, HttpMethod};
+use crate::protect::models::{Chime, ChimePatch};
+use serde_json::Value;
+
+/// Fetch all chimes.
+/// Endpoint: GET /proxy/protect/integration/v1/chimes
+#[derive(Debug, Clone, Default)]
+pub struct GetChimes;
+
+impl Endpoint for GetChimes {
+    const PATH: &'static str = "chimes";
+    const METHOD: HttpMethod = HttpMethod::Get;
+    type Response = Vec<Chime>;
+}
+
+/// Fetch a single chime by ID.
+/// Endpoint: GET /proxy/protect/integration/v1/chimes/{id}
+#[derive(Debug, Clone)]
+pub struct GetChime {
+    pub chime_id: String,
+}
+
+impl GetChime {
+    pub fn new(chime_id: impl Into<String>) -> Self {
+        Self {
+            chime_id: chime_id.into(),
+        }
+    }
+}
+
+impl Endpoint for GetChime {
+    const PATH: &'static str = "chimes/{id}";
+    const METHOD: HttpMethod = HttpMethod::Get;
+    type Response = Chime;
+
+    fn build_path(&self) -> String {
+        format!("chimes/{}", self.chime_id)
+    }
+}
+
+/// Partially update a chime's settings.
+/// Endpoint: PATCH /proxy/protect/integration/v1/chimes/{id}
+#[derive(Debug, Clone)]
+pub struct PatchChime {
+    pub chime_id: String,
+    pub patch: ChimePatch,
+}
+
+impl PatchChime {
+    pub fn new(chime_id: impl Into<String>, patch: ChimePatch) -> Self {
+        Self {
+            chime_id: chime_id.into(),
+            patch,
+        }
+    }
+}
+
+impl Endpoint for PatchChime {
+    const PATH: &'static str = "chimes/{id}";
+    const METHOD: HttpMethod = HttpMethod::Patch;
+    type Response = Chime;
+
+    fn build_path(&self) -> String {
+        format!("chimes/{}", self.chime_id)
+    }
+
+    fn request_body(&self) -> Result<Option<Value>, serde_json::Error> {
+        Ok(Some(serde_json::to_value(&self.patch)?))
+    }
+}

--- a/src/protect/api/chimes.rs
+++ b/src/protect/api/chimes.rs
@@ -34,7 +34,7 @@ impl Endpoint for GetChime {
     type Response = Chime;
 
     fn build_path(&self) -> String {
-        format!("chimes/{}", self.chime_id)
+        format!("chimes/{}", super::encode_id(&self.chime_id))
     }
 }
 
@@ -61,7 +61,7 @@ impl Endpoint for PatchChime {
     type Response = Chime;
 
     fn build_path(&self) -> String {
-        format!("chimes/{}", self.chime_id)
+        format!("chimes/{}", super::encode_id(&self.chime_id))
     }
 
     fn request_body(&self) -> Result<Option<Value>, serde_json::Error> {

--- a/src/protect/api/lights.rs
+++ b/src/protect/api/lights.rs
@@ -34,7 +34,7 @@ impl Endpoint for GetLight {
     type Response = Light;
 
     fn build_path(&self) -> String {
-        format!("lights/{}", self.light_id)
+        format!("lights/{}", super::encode_id(&self.light_id))
     }
 }
 
@@ -61,7 +61,7 @@ impl Endpoint for PatchLight {
     type Response = Light;
 
     fn build_path(&self) -> String {
-        format!("lights/{}", self.light_id)
+        format!("lights/{}", super::encode_id(&self.light_id))
     }
 
     fn request_body(&self) -> Result<Option<Value>, serde_json::Error> {

--- a/src/protect/api/lights.rs
+++ b/src/protect/api/lights.rs
@@ -1,0 +1,70 @@
+use crate::api::endpoint::{Endpoint, HttpMethod};
+use crate::protect::models::{Light, LightPatch};
+use serde_json::Value;
+
+/// Fetch all lights.
+/// Endpoint: GET /proxy/protect/integration/v1/lights
+#[derive(Debug, Clone, Default)]
+pub struct GetLights;
+
+impl Endpoint for GetLights {
+    const PATH: &'static str = "lights";
+    const METHOD: HttpMethod = HttpMethod::Get;
+    type Response = Vec<Light>;
+}
+
+/// Fetch a single light by ID.
+/// Endpoint: GET /proxy/protect/integration/v1/lights/{id}
+#[derive(Debug, Clone)]
+pub struct GetLight {
+    pub light_id: String,
+}
+
+impl GetLight {
+    pub fn new(light_id: impl Into<String>) -> Self {
+        Self {
+            light_id: light_id.into(),
+        }
+    }
+}
+
+impl Endpoint for GetLight {
+    const PATH: &'static str = "lights/{id}";
+    const METHOD: HttpMethod = HttpMethod::Get;
+    type Response = Light;
+
+    fn build_path(&self) -> String {
+        format!("lights/{}", self.light_id)
+    }
+}
+
+/// Partially update a light's settings.
+/// Endpoint: PATCH /proxy/protect/integration/v1/lights/{id}
+#[derive(Debug, Clone)]
+pub struct PatchLight {
+    pub light_id: String,
+    pub patch: LightPatch,
+}
+
+impl PatchLight {
+    pub fn new(light_id: impl Into<String>, patch: LightPatch) -> Self {
+        Self {
+            light_id: light_id.into(),
+            patch,
+        }
+    }
+}
+
+impl Endpoint for PatchLight {
+    const PATH: &'static str = "lights/{id}";
+    const METHOD: HttpMethod = HttpMethod::Patch;
+    type Response = Light;
+
+    fn build_path(&self) -> String {
+        format!("lights/{}", self.light_id)
+    }
+
+    fn request_body(&self) -> Result<Option<Value>, serde_json::Error> {
+        Ok(Some(serde_json::to_value(&self.patch)?))
+    }
+}

--- a/src/protect/api/meta.rs
+++ b/src/protect/api/meta.rs
@@ -1,0 +1,13 @@
+use crate::api::endpoint::{Endpoint, HttpMethod};
+use crate::protect::models::MetaInfo;
+
+/// Fetch Protect application version info.
+/// Endpoint: GET /proxy/protect/integration/v1/meta/info
+#[derive(Debug, Clone, Default)]
+pub struct GetMetaInfo;
+
+impl Endpoint for GetMetaInfo {
+    const PATH: &'static str = "meta/info";
+    const METHOD: HttpMethod = HttpMethod::Get;
+    type Response = MetaInfo;
+}

--- a/src/protect/api/mod.rs
+++ b/src/protect/api/mod.rs
@@ -5,3 +5,18 @@ pub mod meta;
 pub mod nvr;
 pub mod sensors;
 pub mod viewers;
+
+use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
+
+// Encode everything except RFC 3986 unreserved characters, so an ID cannot
+// smuggle path separators or query/fragment delimiters into the request URL.
+const PATH_SEGMENT: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'~');
+
+/// Percent-encode a resource ID for use as a single URL path segment.
+pub(crate) fn encode_id(id: &str) -> String {
+    utf8_percent_encode(id, PATH_SEGMENT).to_string()
+}

--- a/src/protect/api/mod.rs
+++ b/src/protect/api/mod.rs
@@ -1,0 +1,7 @@
+pub mod cameras;
+pub mod chimes;
+pub mod lights;
+pub mod meta;
+pub mod nvr;
+pub mod sensors;
+pub mod viewers;

--- a/src/protect/api/nvr.rs
+++ b/src/protect/api/nvr.rs
@@ -1,0 +1,15 @@
+use crate::api::endpoint::{Endpoint, HttpMethod};
+use crate::protect::models::Nvr;
+
+/// Fetch NVR / console information.
+/// Endpoint: GET /proxy/protect/integration/v1/nvrs
+///
+/// The console returns a single NVR object (not an array).
+#[derive(Debug, Clone, Default)]
+pub struct GetNvr;
+
+impl Endpoint for GetNvr {
+    const PATH: &'static str = "nvrs";
+    const METHOD: HttpMethod = HttpMethod::Get;
+    type Response = Nvr;
+}

--- a/src/protect/api/sensors.rs
+++ b/src/protect/api/sensors.rs
@@ -34,7 +34,7 @@ impl Endpoint for GetSensor {
     type Response = Sensor;
 
     fn build_path(&self) -> String {
-        format!("sensors/{}", self.sensor_id)
+        format!("sensors/{}", super::encode_id(&self.sensor_id))
     }
 }
 
@@ -61,7 +61,7 @@ impl Endpoint for PatchSensor {
     type Response = Sensor;
 
     fn build_path(&self) -> String {
-        format!("sensors/{}", self.sensor_id)
+        format!("sensors/{}", super::encode_id(&self.sensor_id))
     }
 
     fn request_body(&self) -> Result<Option<Value>, serde_json::Error> {

--- a/src/protect/api/sensors.rs
+++ b/src/protect/api/sensors.rs
@@ -1,0 +1,70 @@
+use crate::api::endpoint::{Endpoint, HttpMethod};
+use crate::protect::models::{Sensor, SensorPatch};
+use serde_json::Value;
+
+/// Fetch all sensors.
+/// Endpoint: GET /proxy/protect/integration/v1/sensors
+#[derive(Debug, Clone, Default)]
+pub struct GetSensors;
+
+impl Endpoint for GetSensors {
+    const PATH: &'static str = "sensors";
+    const METHOD: HttpMethod = HttpMethod::Get;
+    type Response = Vec<Sensor>;
+}
+
+/// Fetch a single sensor by ID.
+/// Endpoint: GET /proxy/protect/integration/v1/sensors/{id}
+#[derive(Debug, Clone)]
+pub struct GetSensor {
+    pub sensor_id: String,
+}
+
+impl GetSensor {
+    pub fn new(sensor_id: impl Into<String>) -> Self {
+        Self {
+            sensor_id: sensor_id.into(),
+        }
+    }
+}
+
+impl Endpoint for GetSensor {
+    const PATH: &'static str = "sensors/{id}";
+    const METHOD: HttpMethod = HttpMethod::Get;
+    type Response = Sensor;
+
+    fn build_path(&self) -> String {
+        format!("sensors/{}", self.sensor_id)
+    }
+}
+
+/// Partially update a sensor's settings.
+/// Endpoint: PATCH /proxy/protect/integration/v1/sensors/{id}
+#[derive(Debug, Clone)]
+pub struct PatchSensor {
+    pub sensor_id: String,
+    pub patch: SensorPatch,
+}
+
+impl PatchSensor {
+    pub fn new(sensor_id: impl Into<String>, patch: SensorPatch) -> Self {
+        Self {
+            sensor_id: sensor_id.into(),
+            patch,
+        }
+    }
+}
+
+impl Endpoint for PatchSensor {
+    const PATH: &'static str = "sensors/{id}";
+    const METHOD: HttpMethod = HttpMethod::Patch;
+    type Response = Sensor;
+
+    fn build_path(&self) -> String {
+        format!("sensors/{}", self.sensor_id)
+    }
+
+    fn request_body(&self) -> Result<Option<Value>, serde_json::Error> {
+        Ok(Some(serde_json::to_value(&self.patch)?))
+    }
+}

--- a/src/protect/api/viewers.rs
+++ b/src/protect/api/viewers.rs
@@ -1,0 +1,70 @@
+use crate::api::endpoint::{Endpoint, HttpMethod};
+use crate::protect::models::{Viewer, ViewerPatch};
+use serde_json::Value;
+
+/// Fetch all viewers.
+/// Endpoint: GET /proxy/protect/integration/v1/viewers
+#[derive(Debug, Clone, Default)]
+pub struct GetViewers;
+
+impl Endpoint for GetViewers {
+    const PATH: &'static str = "viewers";
+    const METHOD: HttpMethod = HttpMethod::Get;
+    type Response = Vec<Viewer>;
+}
+
+/// Fetch a single viewer by ID.
+/// Endpoint: GET /proxy/protect/integration/v1/viewers/{id}
+#[derive(Debug, Clone)]
+pub struct GetViewer {
+    pub viewer_id: String,
+}
+
+impl GetViewer {
+    pub fn new(viewer_id: impl Into<String>) -> Self {
+        Self {
+            viewer_id: viewer_id.into(),
+        }
+    }
+}
+
+impl Endpoint for GetViewer {
+    const PATH: &'static str = "viewers/{id}";
+    const METHOD: HttpMethod = HttpMethod::Get;
+    type Response = Viewer;
+
+    fn build_path(&self) -> String {
+        format!("viewers/{}", self.viewer_id)
+    }
+}
+
+/// Partially update a viewer's settings.
+/// Endpoint: PATCH /proxy/protect/integration/v1/viewers/{id}
+#[derive(Debug, Clone)]
+pub struct PatchViewer {
+    pub viewer_id: String,
+    pub patch: ViewerPatch,
+}
+
+impl PatchViewer {
+    pub fn new(viewer_id: impl Into<String>, patch: ViewerPatch) -> Self {
+        Self {
+            viewer_id: viewer_id.into(),
+            patch,
+        }
+    }
+}
+
+impl Endpoint for PatchViewer {
+    const PATH: &'static str = "viewers/{id}";
+    const METHOD: HttpMethod = HttpMethod::Patch;
+    type Response = Viewer;
+
+    fn build_path(&self) -> String {
+        format!("viewers/{}", self.viewer_id)
+    }
+
+    fn request_body(&self) -> Result<Option<Value>, serde_json::Error> {
+        Ok(Some(serde_json::to_value(&self.patch)?))
+    }
+}

--- a/src/protect/api/viewers.rs
+++ b/src/protect/api/viewers.rs
@@ -34,7 +34,7 @@ impl Endpoint for GetViewer {
     type Response = Viewer;
 
     fn build_path(&self) -> String {
-        format!("viewers/{}", self.viewer_id)
+        format!("viewers/{}", super::encode_id(&self.viewer_id))
     }
 }
 
@@ -61,7 +61,7 @@ impl Endpoint for PatchViewer {
     type Response = Viewer;
 
     fn build_path(&self) -> String {
-        format!("viewers/{}", self.viewer_id)
+        format!("viewers/{}", super::encode_id(&self.viewer_id))
     }
 
     fn request_body(&self) -> Result<Option<Value>, serde_json::Error> {

--- a/src/protect/client.rs
+++ b/src/protect/client.rs
@@ -128,7 +128,9 @@ impl ProtectClient {
     pub async fn snapshot(&self, camera_id: &str, high_quality: bool) -> Result<Vec<u8>> {
         let url = format!(
             "{}/{}/cameras/{}/snapshot",
-            self.base_url, PROTECT_BASE_PATH, camera_id
+            self.base_url,
+            PROTECT_BASE_PATH,
+            crate::protect::api::encode_id(camera_id)
         );
 
         let response = self
@@ -143,7 +145,9 @@ impl ProtectClient {
             .await?;
 
         if !response.status().is_success() {
-            return Err(Error::Request(response.error_for_status().unwrap_err()));
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(Error::Api { status, body });
         }
 
         Ok(response.bytes().await?.to_vec())

--- a/src/protect/client.rs
+++ b/src/protect/client.rs
@@ -1,0 +1,262 @@
+use crate::api::endpoint::Endpoint;
+use crate::error::{Error, Result};
+use crate::protect::api::{
+    cameras::{
+        CreateRtspsStream, DeleteRtspsStream, GetCamera, GetCameras, GetRtspsStreams, PatchCamera,
+    },
+    chimes::{GetChime, GetChimes, PatchChime},
+    lights::{GetLight, GetLights, PatchLight},
+    meta::GetMetaInfo,
+    nvr::GetNvr,
+    sensors::{GetSensor, GetSensors, PatchSensor},
+    viewers::{GetViewer, GetViewers, PatchViewer},
+};
+use crate::protect::models::{
+    Camera, CameraPatch, Chime, ChimePatch, Light, LightPatch, MetaInfo, Nvr, RtspsQuality,
+    RtspsStreams, Sensor, SensorPatch, Viewer, ViewerPatch,
+};
+use crate::transport;
+use reqwest::Client;
+
+/// Base path of the official Protect Integration API on a local console.
+pub const PROTECT_BASE_PATH: &str = "proxy/protect/integration/v1";
+
+/// Client for the official UniFi Protect Integration API.
+///
+/// Authenticates with an `X-API-Key` header. Generate a key in the Protect
+/// app under Settings -> Control Plane -> Integrations.
+///
+/// # Example
+/// ```no_run
+/// use rustifi::protect::ProtectClient;
+///
+/// # async fn run() -> rustifi::Result<()> {
+/// // Local consoles usually have self-signed certs; see `new_insecure`.
+/// let client = ProtectClient::new("https://protect.example.com", "your-api-key")?;
+/// let cameras = client.cameras().await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone, Debug)]
+pub struct ProtectClient {
+    http: Client,
+    base_url: String,
+    api_key: String,
+    accept_invalid_certs: bool,
+}
+
+impl ProtectClient {
+    /// Create a new Protect client with strict TLS validation.
+    ///
+    /// # Errors
+    /// Returns an error if the API key contains invalid HTTP header characters.
+    pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Result<Self> {
+        Self::build(base_url, api_key, false)
+    }
+
+    /// Create a new Protect client that accepts invalid/self-signed TLS certificates.
+    ///
+    /// # Security Warning
+    /// **This disables TLS certificate validation.** Only use this for local
+    /// consoles with self-signed certificates on trusted networks. Using this
+    /// over untrusted networks exposes you to man-in-the-middle attacks.
+    ///
+    /// # Errors
+    /// Returns an error if the API key contains invalid HTTP header characters.
+    pub fn new_insecure(base_url: impl Into<String>, api_key: impl Into<String>) -> Result<Self> {
+        Self::build(base_url, api_key, true)
+    }
+
+    fn build(
+        base_url: impl Into<String>,
+        api_key: impl Into<String>,
+        accept_invalid_certs: bool,
+    ) -> Result<Self> {
+        // Validate the API key can be parsed as a header value early
+        let api_key = api_key.into();
+        let _: reqwest::header::HeaderValue = api_key.parse()?;
+
+        let http = transport::build_http_client(accept_invalid_certs, false)?;
+
+        Ok(Self {
+            http,
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            api_key,
+            accept_invalid_certs,
+        })
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    pub fn api_key(&self) -> &str {
+        &self.api_key
+    }
+
+    pub(crate) fn accepts_invalid_certs(&self) -> bool {
+        self.accept_invalid_certs
+    }
+
+    /// Execute a request for an endpoint instance.
+    /// Use this when the endpoint has dynamic path parameters.
+    pub async fn execute<E>(&self, endpoint: &E) -> Result<E::Response>
+    where
+        E: Endpoint,
+        E::Response: for<'a> serde::Deserialize<'a>,
+    {
+        let url_prefix = format!("{}/{}", self.base_url, PROTECT_BASE_PATH);
+        transport::execute_endpoint(&self.http, &url_prefix, Some(&self.api_key), endpoint).await
+    }
+
+    /// Execute a request for endpoints without dynamic path parameters.
+    /// For endpoints with path parameters, use `execute()` instead.
+    pub async fn request<E>(&self) -> Result<E::Response>
+    where
+        E: Endpoint + Default,
+        E::Response: for<'a> serde::Deserialize<'a>,
+    {
+        self.execute(&E::default()).await
+    }
+
+    /// Fetch a JPEG snapshot from a camera.
+    /// Endpoint: GET /proxy/protect/integration/v1/cameras/{id}/snapshot
+    ///
+    /// Returns the raw JPEG bytes. This is a dedicated method because the
+    /// [`Endpoint`] trait models JSON responses only; if more binary endpoints
+    /// are added later, a `RawEndpoint` trait may replace this.
+    pub async fn snapshot(&self, camera_id: &str, high_quality: bool) -> Result<Vec<u8>> {
+        let url = format!(
+            "{}/{}/cameras/{}/snapshot",
+            self.base_url, PROTECT_BASE_PATH, camera_id
+        );
+
+        let response = self
+            .http
+            .get(&url)
+            .header(
+                "X-API-Key",
+                self.api_key.parse::<reqwest::header::HeaderValue>()?,
+            )
+            .query(&[("highQuality", high_quality.to_string())])
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(Error::Request(response.error_for_status().unwrap_err()));
+        }
+
+        Ok(response.bytes().await?.to_vec())
+    }
+
+    /// Fetch Protect application version info.
+    pub async fn meta_info(&self) -> Result<MetaInfo> {
+        self.execute(&GetMetaInfo).await
+    }
+
+    /// Fetch all cameras.
+    pub async fn cameras(&self) -> Result<Vec<Camera>> {
+        self.execute(&GetCameras).await
+    }
+
+    /// Fetch a single camera by ID.
+    pub async fn camera(&self, id: &str) -> Result<Camera> {
+        self.execute(&GetCamera::new(id)).await
+    }
+
+    /// Partially update a camera's settings.
+    pub async fn patch_camera(&self, id: &str, patch: CameraPatch) -> Result<Camera> {
+        self.execute(&PatchCamera::new(id, patch)).await
+    }
+
+    /// Fetch the currently provisioned RTSPS stream URLs for a camera.
+    pub async fn rtsps_streams(&self, camera_id: &str) -> Result<RtspsStreams> {
+        self.execute(&GetRtspsStreams::new(camera_id)).await
+    }
+
+    /// Provision RTSPS streams for the given qualities.
+    pub async fn create_rtsps_streams(
+        &self,
+        camera_id: &str,
+        qualities: Vec<RtspsQuality>,
+    ) -> Result<RtspsStreams> {
+        self.execute(&CreateRtspsStream::new(camera_id, qualities))
+            .await
+    }
+
+    /// Remove provisioned RTSPS streams for the given qualities.
+    pub async fn delete_rtsps_streams(
+        &self,
+        camera_id: &str,
+        qualities: Vec<RtspsQuality>,
+    ) -> Result<()> {
+        self.execute(&DeleteRtspsStream::new(camera_id, qualities))
+            .await?;
+        Ok(())
+    }
+
+    /// Fetch all lights.
+    pub async fn lights(&self) -> Result<Vec<Light>> {
+        self.execute(&GetLights).await
+    }
+
+    /// Fetch a single light by ID.
+    pub async fn light(&self, id: &str) -> Result<Light> {
+        self.execute(&GetLight::new(id)).await
+    }
+
+    /// Partially update a light's settings.
+    pub async fn patch_light(&self, id: &str, patch: LightPatch) -> Result<Light> {
+        self.execute(&PatchLight::new(id, patch)).await
+    }
+
+    /// Fetch all sensors.
+    pub async fn sensors(&self) -> Result<Vec<Sensor>> {
+        self.execute(&GetSensors).await
+    }
+
+    /// Fetch a single sensor by ID.
+    pub async fn sensor(&self, id: &str) -> Result<Sensor> {
+        self.execute(&GetSensor::new(id)).await
+    }
+
+    /// Partially update a sensor's settings.
+    pub async fn patch_sensor(&self, id: &str, patch: SensorPatch) -> Result<Sensor> {
+        self.execute(&PatchSensor::new(id, patch)).await
+    }
+
+    /// Fetch all chimes.
+    pub async fn chimes(&self) -> Result<Vec<Chime>> {
+        self.execute(&GetChimes).await
+    }
+
+    /// Fetch a single chime by ID.
+    pub async fn chime(&self, id: &str) -> Result<Chime> {
+        self.execute(&GetChime::new(id)).await
+    }
+
+    /// Partially update a chime's settings.
+    pub async fn patch_chime(&self, id: &str, patch: ChimePatch) -> Result<Chime> {
+        self.execute(&PatchChime::new(id, patch)).await
+    }
+
+    /// Fetch all viewers.
+    pub async fn viewers(&self) -> Result<Vec<Viewer>> {
+        self.execute(&GetViewers).await
+    }
+
+    /// Fetch a single viewer by ID.
+    pub async fn viewer(&self, id: &str) -> Result<Viewer> {
+        self.execute(&GetViewer::new(id)).await
+    }
+
+    /// Partially update a viewer's settings.
+    pub async fn patch_viewer(&self, id: &str, patch: ViewerPatch) -> Result<Viewer> {
+        self.execute(&PatchViewer::new(id, patch)).await
+    }
+
+    /// Fetch NVR / console information.
+    pub async fn nvr(&self) -> Result<Nvr> {
+        self.execute(&GetNvr).await
+    }
+}

--- a/src/protect/mod.rs
+++ b/src/protect/mod.rs
@@ -1,0 +1,28 @@
+//! UniFi Protect Integration API support.
+//!
+//! This module wraps the official Protect Integration API (Protect >= 5.3),
+//! available at `https://{console}/proxy/protect/integration/v1`. It uses the
+//! same `X-API-Key` authentication as the Network Integration API.
+//!
+//! Enable with the `protect` cargo feature:
+//!
+//! ```toml
+//! rustifi = { version = "2", features = ["protect"] }
+//! ```
+
+pub mod api;
+pub mod client;
+pub mod models;
+pub mod ws;
+
+pub use client::{ProtectClient, PROTECT_BASE_PATH};
+
+pub mod prelude {
+    pub use crate::protect::client::ProtectClient;
+    pub use crate::protect::models::{
+        Camera, CameraPatch, Chime, Light, ModelKey, Nvr, ProtectDeviceState, ProtectEvent,
+        ProtectEventType, RtspsQuality, RtspsStreams, Sensor, SmartDetectType, Viewer, WsAction,
+        WsMessage,
+    };
+    pub use crate::protect::ws::{DeviceUpdateStream, ProtectEventStream};
+}

--- a/src/protect/models/camera.rs
+++ b/src/protect/models/camera.rs
@@ -1,0 +1,206 @@
+use super::common::{ModelKey, ProtectDeviceState};
+use crate::models::common::MacAddress;
+use serde::{Deserialize, Serialize};
+
+/// A Protect camera as returned by `GET /cameras` and `GET /cameras/{id}`.
+///
+/// Fields that are not guaranteed to be present on every camera model or
+/// Protect release are `Option` — Ubiquiti adds fields per release.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Camera {
+    pub id: String,
+    #[serde(default)]
+    pub model_key: ModelKey,
+    #[serde(default)]
+    pub state: ProtectDeviceState,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub mac: Option<MacAddress>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default, rename = "type")]
+    pub type_field: Option<String>,
+    #[serde(default)]
+    pub firmware_version: Option<String>,
+    #[serde(default)]
+    pub is_mic_enabled: Option<bool>,
+    #[serde(default)]
+    pub mic_volume: Option<u8>,
+    #[serde(default)]
+    pub video_mode: Option<String>,
+    #[serde(default)]
+    pub hdr_type: Option<String>,
+    #[serde(default)]
+    pub osd_settings: Option<OsdSettings>,
+    #[serde(default)]
+    pub led_settings: Option<LedSettings>,
+    #[serde(default)]
+    pub lcd_message: Option<LcdMessage>,
+    #[serde(default)]
+    pub smart_detect_settings: Option<SmartDetectSettings>,
+    #[serde(default)]
+    pub recording_settings: Option<RecordingSettings>,
+    #[serde(default)]
+    pub feature_flags: Option<CameraFeatureFlags>,
+    #[serde(default)]
+    pub is_third_party_camera: Option<bool>,
+    #[serde(default)]
+    pub active_patrol_slot: Option<i64>,
+}
+
+/// On-screen display settings for a camera.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct OsdSettings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_name_enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_date_enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_logo_enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_debug_enabled: Option<bool>,
+}
+
+/// Status LED settings for a camera.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LedSettings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_enabled: Option<bool>,
+}
+
+/// LCD message shown on doorbell cameras.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LcdMessage {
+    #[serde(default, rename = "type", skip_serializing_if = "Option::is_none")]
+    pub type_field: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reset_at: Option<i64>,
+}
+
+/// Smart detection configuration for a camera.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SmartDetectSettings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub object_types: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_tracking_object_types: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audio_types: Option<Vec<String>>,
+}
+
+/// Recording configuration for a camera.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordingSettings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pre_padding_secs: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub post_padding_secs: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retention_duration_ms: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_motion_event_delay: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suppress_illumination_surge: Option<bool>,
+}
+
+/// Capabilities reported by a camera.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CameraFeatureFlags {
+    #[serde(default)]
+    pub has_hdr: Option<bool>,
+    #[serde(default)]
+    pub has_mic: Option<bool>,
+    #[serde(default)]
+    pub has_led_status: Option<bool>,
+    #[serde(default)]
+    pub has_speaker: Option<bool>,
+    #[serde(default)]
+    pub has_chime: Option<bool>,
+    #[serde(default)]
+    pub has_smart_detect: Option<bool>,
+    #[serde(default)]
+    pub smart_detect_types: Option<Vec<String>>,
+    #[serde(default)]
+    pub smart_detect_audio_types: Option<Vec<String>>,
+    #[serde(default)]
+    pub video_modes: Option<Vec<String>>,
+    #[serde(default)]
+    pub hdr_types: Option<Vec<String>>,
+    #[serde(default)]
+    pub is_ptz: Option<bool>,
+}
+
+/// Partial update body for `PATCH /cameras/{id}`.
+///
+/// Only fields set to `Some` are serialized and sent.
+#[derive(Clone, Debug, Default, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CameraPatch {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub osd_settings: Option<OsdSettings>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub led_settings: Option<LedSettings>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lcd_message: Option<LcdMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mic_volume: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub video_mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hdr_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub smart_detect_settings: Option<SmartDetectSettings>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recording_settings: Option<RecordingSettings>,
+}
+
+/// RTSPS stream URLs per quality, from the `/cameras/{id}/rtsps-stream` endpoints.
+///
+/// A quality is `None` when no stream is provisioned for it.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RtspsStreams {
+    #[serde(default)]
+    pub high: Option<String>,
+    #[serde(default)]
+    pub medium: Option<String>,
+    #[serde(default)]
+    pub low: Option<String>,
+    #[serde(default)]
+    pub package: Option<String>,
+}
+
+/// Stream quality selector for RTSPS stream management.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub enum RtspsQuality {
+    High,
+    Medium,
+    Low,
+    Package,
+}
+
+impl RtspsQuality {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RtspsQuality::High => "high",
+            RtspsQuality::Medium => "medium",
+            RtspsQuality::Low => "low",
+            RtspsQuality::Package => "package",
+        }
+    }
+}

--- a/src/protect/models/chime.rs
+++ b/src/protect/models/chime.rs
@@ -1,0 +1,56 @@
+use super::common::{ModelKey, ProtectDeviceState};
+use crate::models::common::MacAddress;
+use serde::{Deserialize, Serialize};
+
+/// A Protect chime as returned by `GET /chimes` and `GET /chimes/{id}`.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Chime {
+    pub id: String,
+    #[serde(default)]
+    pub model_key: ModelKey,
+    #[serde(default)]
+    pub state: ProtectDeviceState,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub mac: Option<MacAddress>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub firmware_version: Option<String>,
+    #[serde(default)]
+    pub volume: Option<u8>,
+    #[serde(default)]
+    pub camera_ids: Option<Vec<String>>,
+    #[serde(default)]
+    pub ring_settings: Option<Vec<RingSetting>>,
+}
+
+/// Per-camera ring configuration for a chime.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RingSetting {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub camera_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repeat_times: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub track_no: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub volume: Option<u8>,
+}
+
+/// Partial update body for `PATCH /chimes/{id}`.
+#[derive(Clone, Debug, Default, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ChimePatch {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub volume: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub camera_ids: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ring_settings: Option<Vec<RingSetting>>,
+}

--- a/src/protect/models/common.rs
+++ b/src/protect/models/common.rs
@@ -1,0 +1,62 @@
+use serde::Deserialize;
+
+/// Connection state reported for every Protect device.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ProtectDeviceState {
+    Connected,
+    Connecting,
+    Disconnected,
+    #[serde(other)]
+    #[default]
+    Unknown,
+}
+
+/// The `modelKey` discriminator present on every Protect object.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub enum ModelKey {
+    Camera,
+    Light,
+    Sensor,
+    Chime,
+    Viewer,
+    Nvr,
+    Doorlock,
+    Event,
+    #[serde(other)]
+    #[default]
+    Unknown,
+}
+
+/// A millisecond-precision Unix timestamp, as used by Protect events.
+///
+/// Distinct from [`crate::models::common::Timestamp`], which holds seconds.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct TimestampMillis(pub i64);
+
+impl TimestampMillis {
+    pub fn as_millis(&self) -> i64 {
+        self.0
+    }
+
+    pub fn as_secs(&self) -> i64 {
+        self.0 / 1000
+    }
+}
+
+impl std::fmt::Display for TimestampMillis {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for TimestampMillis {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let n = i64::deserialize(deserializer)?;
+        Ok(TimestampMillis(n))
+    }
+}

--- a/src/protect/models/event.rs
+++ b/src/protect/models/event.rs
@@ -1,0 +1,96 @@
+use super::common::ModelKey;
+use serde::Deserialize;
+
+/// Envelope for messages received on the Protect WebSocket subscriptions.
+///
+/// Both `/subscribe/events` and `/subscribe/devices` deliver frames shaped as
+/// `{"type": "add" | "update", "item": {...}}`.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct WsMessage<T> {
+    #[serde(rename = "type")]
+    pub action: WsAction,
+    pub item: T,
+}
+
+/// The action discriminator on a WebSocket frame.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub enum WsAction {
+    Add,
+    Update,
+    Remove,
+    #[serde(other)]
+    #[default]
+    Unknown,
+}
+
+/// A motion, smart-detection, doorbell, or connectivity event.
+///
+/// Delivered via the `/subscribe/events` WebSocket. Events arrive as an `add`
+/// when they start and an `update` (with `end` set) when they finish.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProtectEvent {
+    pub id: String,
+    #[serde(default)]
+    pub model_key: ModelKey,
+    #[serde(default, rename = "type")]
+    pub event_type: ProtectEventType,
+    /// Event start, epoch milliseconds.
+    #[serde(default)]
+    pub start: i64,
+    /// Event end, epoch milliseconds. `None` while the event is ongoing.
+    #[serde(default)]
+    pub end: Option<i64>,
+    /// ID of the device that produced the event.
+    #[serde(default)]
+    pub device: String,
+    #[serde(default)]
+    pub smart_detect_types: Vec<SmartDetectType>,
+}
+
+/// The kind of a Protect event.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub enum ProtectEventType {
+    Motion,
+    SmartDetectZone,
+    SmartDetectLine,
+    /// Doorbell ring.
+    Doorbell,
+    Disconnect,
+    #[serde(other)]
+    #[default]
+    Unknown,
+}
+
+/// Object classes recognized by smart detection.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub enum SmartDetectType {
+    Person,
+    Vehicle,
+    Animal,
+    Face,
+    Package,
+    LicensePlate,
+    #[serde(other)]
+    #[default]
+    Unknown,
+}
+
+/// A partial device-state patch from the `/subscribe/devices` WebSocket.
+///
+/// Frames carry heterogeneous partial updates for any device type, so only the
+/// identifying fields are typed; the remaining fields are kept as raw JSON in
+/// [`Self::fields`].
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceUpdate {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub model_key: ModelKey,
+    #[serde(flatten)]
+    pub fields: serde_json::Map<String, serde_json::Value>,
+}

--- a/src/protect/models/light.rs
+++ b/src/protect/models/light.rs
@@ -1,0 +1,72 @@
+use super::common::{ModelKey, ProtectDeviceState};
+use crate::models::common::MacAddress;
+use serde::{Deserialize, Serialize};
+
+/// A Protect floodlight as returned by `GET /lights` and `GET /lights/{id}`.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Light {
+    pub id: String,
+    #[serde(default)]
+    pub model_key: ModelKey,
+    #[serde(default)]
+    pub state: ProtectDeviceState,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub mac: Option<MacAddress>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub firmware_version: Option<String>,
+    #[serde(default)]
+    pub is_light_on: Option<bool>,
+    #[serde(default)]
+    pub is_pir_motion_detected: Option<bool>,
+    #[serde(default)]
+    pub is_locating: Option<bool>,
+    #[serde(default)]
+    pub camera_id: Option<String>,
+    #[serde(default)]
+    pub light_mode_settings: Option<LightModeSettings>,
+    #[serde(default)]
+    pub light_device_settings: Option<LightDeviceSettings>,
+}
+
+/// When and how the light activates.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LightModeSettings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enable_at: Option<String>,
+}
+
+/// Hardware settings for the light.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LightDeviceSettings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_indicator_enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub led_level: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pir_duration: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pir_sensitivity: Option<i64>,
+}
+
+/// Partial update body for `PATCH /lights/{id}`.
+#[derive(Clone, Debug, Default, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LightPatch {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_light_on: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub light_mode_settings: Option<LightModeSettings>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub light_device_settings: Option<LightDeviceSettings>,
+}

--- a/src/protect/models/mod.rs
+++ b/src/protect/models/mod.rs
@@ -1,0 +1,25 @@
+pub mod camera;
+pub mod chime;
+pub mod common;
+pub mod event;
+pub mod light;
+pub mod nvr;
+pub mod sensor;
+pub mod viewer;
+
+pub use camera::{
+    Camera, CameraFeatureFlags, CameraPatch, LcdMessage, LedSettings, OsdSettings,
+    RecordingSettings, RtspsQuality, RtspsStreams, SmartDetectSettings,
+};
+pub use chime::{Chime, ChimePatch, RingSetting};
+pub use common::{ModelKey, ProtectDeviceState, TimestampMillis};
+pub use event::{
+    DeviceUpdate, ProtectEvent, ProtectEventType, SmartDetectType, WsAction, WsMessage,
+};
+pub use light::{Light, LightDeviceSettings, LightModeSettings, LightPatch};
+pub use nvr::{MetaInfo, Nvr};
+pub use sensor::{
+    BatteryStatus, Sensor, SensorAlarmSettings, SensorPatch, SensorReading, SensorSettings,
+    SensorStats,
+};
+pub use viewer::{Viewer, ViewerPatch};

--- a/src/protect/models/nvr.rs
+++ b/src/protect/models/nvr.rs
@@ -1,0 +1,41 @@
+use super::common::ModelKey;
+use crate::models::common::MacAddress;
+use serde::Deserialize;
+
+/// The Protect NVR / console as returned by `GET /nvrs`.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Nvr {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub model_key: ModelKey,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub mac: Option<MacAddress>,
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub firmware_version: Option<String>,
+    #[serde(default)]
+    pub uptime: Option<i64>,
+    #[serde(default)]
+    pub hardware_platform: Option<String>,
+    #[serde(default)]
+    pub hardware_id: Option<String>,
+    #[serde(default)]
+    pub host: Option<String>,
+    #[serde(default)]
+    pub ports: Option<serde_json::Value>,
+    #[serde(default)]
+    pub storage_stats: Option<serde_json::Value>,
+}
+
+/// Application version info from `GET /meta/info`.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MetaInfo {
+    #[serde(default)]
+    pub application_version: String,
+}

--- a/src/protect/models/sensor.rs
+++ b/src/protect/models/sensor.rs
@@ -1,0 +1,116 @@
+use super::common::{ModelKey, ProtectDeviceState};
+use crate::models::common::MacAddress;
+use serde::{Deserialize, Serialize};
+
+/// A Protect sensor as returned by `GET /sensors` and `GET /sensors/{id}`.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Sensor {
+    pub id: String,
+    #[serde(default)]
+    pub model_key: ModelKey,
+    #[serde(default)]
+    pub state: ProtectDeviceState,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub mac: Option<MacAddress>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub firmware_version: Option<String>,
+    #[serde(default)]
+    pub mount_type: Option<String>,
+    #[serde(default)]
+    pub is_opened: Option<bool>,
+    #[serde(default)]
+    pub is_motion_detected: Option<bool>,
+    #[serde(default)]
+    pub battery_status: Option<BatteryStatus>,
+    #[serde(default)]
+    pub stats: Option<SensorStats>,
+    #[serde(default)]
+    pub alarm_settings: Option<SensorAlarmSettings>,
+    #[serde(default)]
+    pub light_settings: Option<SensorSettings>,
+    #[serde(default)]
+    pub motion_settings: Option<SensorSettings>,
+    #[serde(default)]
+    pub temperature_settings: Option<SensorSettings>,
+    #[serde(default)]
+    pub humidity_settings: Option<SensorSettings>,
+}
+
+/// Battery level and charge state.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BatteryStatus {
+    #[serde(default)]
+    pub percentage: Option<i64>,
+    #[serde(default)]
+    pub is_low: Option<bool>,
+}
+
+/// Latest environmental readings from the sensor.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SensorStats {
+    #[serde(default)]
+    pub light: Option<SensorReading>,
+    #[serde(default)]
+    pub temperature: Option<SensorReading>,
+    #[serde(default)]
+    pub humidity: Option<SensorReading>,
+}
+
+/// A single reading with its value and status.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SensorReading {
+    #[serde(default)]
+    pub value: Option<f64>,
+    #[serde(default)]
+    pub status: Option<String>,
+}
+
+/// Alarm sound detection settings.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SensorAlarmSettings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_enabled: Option<bool>,
+}
+
+/// Generic enable/threshold settings block shared by sensor capabilities.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SensorSettings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sensitivity: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub low_threshold: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub high_threshold: Option<f64>,
+}
+
+/// Partial update body for `PATCH /sensors/{id}`.
+#[derive(Clone, Debug, Default, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SensorPatch {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mount_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alarm_settings: Option<SensorAlarmSettings>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub light_settings: Option<SensorSettings>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub motion_settings: Option<SensorSettings>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature_settings: Option<SensorSettings>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub humidity_settings: Option<SensorSettings>,
+}

--- a/src/protect/models/viewer.rs
+++ b/src/protect/models/viewer.rs
@@ -1,0 +1,35 @@
+use super::common::{ModelKey, ProtectDeviceState};
+use crate::models::common::MacAddress;
+use serde::{Deserialize, Serialize};
+
+/// A Protect viewer (ViewPort) as returned by `GET /viewers` and `GET /viewers/{id}`.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Viewer {
+    pub id: String,
+    #[serde(default)]
+    pub model_key: ModelKey,
+    #[serde(default)]
+    pub state: ProtectDeviceState,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub mac: Option<MacAddress>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub firmware_version: Option<String>,
+    /// ID of the liveview currently shown on this viewer.
+    #[serde(default)]
+    pub liveview: Option<String>,
+}
+
+/// Partial update body for `PATCH /viewers/{id}`.
+#[derive(Clone, Debug, Default, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ViewerPatch {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub liveview: Option<String>,
+}

--- a/src/protect/ws.rs
+++ b/src/protect/ws.rs
@@ -1,0 +1,169 @@
+//! Live event subscriptions over the Protect Integration API WebSocket.
+//!
+//! The streams end (`poll_next` returns `None`) when the console closes the
+//! connection or a transport error occurs. The API offers no replay cursor, so
+//! events occurring while disconnected are lost; reconnect by calling the
+//! subscribe method again:
+//!
+//! ```no_run
+//! # use futures::StreamExt;
+//! # async fn run(client: rustifi::protect::ProtectClient) -> rustifi::Result<()> {
+//! loop {
+//!     let mut stream = client.subscribe_events().await?;
+//!     while let Some(msg) = stream.next().await {
+//!         match msg {
+//!             Ok(event) => println!("{:?}", event),
+//!             Err(e) => eprintln!("stream error: {}", e),
+//!         }
+//!     }
+//!     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+//! }
+//! # }
+//! ```
+
+use crate::error::{Error, Result};
+use crate::protect::client::{ProtectClient, PROTECT_BASE_PATH};
+use crate::protect::models::{DeviceUpdate, ProtectEvent, WsMessage};
+use futures::stream::Stream;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{
+    connect_async_tls_with_config, Connector, MaybeTlsStream, WebSocketStream,
+};
+
+type WsStream = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+
+/// Stream of Protect events from `/subscribe/events`.
+pub type ProtectEventStream = TypedWsStream<ProtectEvent>;
+
+/// Stream of partial device updates from `/subscribe/devices`.
+pub type DeviceUpdateStream = TypedWsStream<DeviceUpdate>;
+
+/// A WebSocket connection yielding typed `{"type": ..., "item": ...}` frames.
+///
+/// - Text frames are deserialized to `WsMessage<T>`; failures yield
+///   [`Error::Parse`] without ending the stream.
+/// - Ping/pong/binary frames are skipped (tungstenite answers pings itself).
+/// - A close frame or transport error yields [`Error::WebSocket`] and then the
+///   stream ends.
+pub struct TypedWsStream<T> {
+    inner: WsStream,
+    // Set after a close frame or transport error; the stream then ends
+    // instead of surfacing follow-up frames from the closing handshake.
+    terminated: bool,
+    _marker: PhantomData<T>,
+}
+
+impl<T> std::fmt::Debug for TypedWsStream<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TypedWsStream").finish_non_exhaustive()
+    }
+}
+
+impl<T> Stream for TypedWsStream<T>
+where
+    T: for<'a> serde::Deserialize<'a> + Unpin,
+{
+    type Item = Result<WsMessage<T>>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.terminated {
+            return Poll::Ready(None);
+        }
+        loop {
+            match Pin::new(&mut self.inner).poll_next(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(None) => {
+                    self.terminated = true;
+                    return Poll::Ready(None);
+                }
+                Poll::Ready(Some(Ok(Message::Text(text)))) => {
+                    let parsed = serde_json::from_str::<WsMessage<T>>(text.as_str())
+                        .map_err(|e| Error::Parse(format!("{}\nFrame: {}", e, text)));
+                    return Poll::Ready(Some(parsed));
+                }
+                Poll::Ready(Some(Ok(Message::Close(frame)))) => {
+                    self.terminated = true;
+                    let reason = frame
+                        .map(|f| format!("connection closed: {} {}", f.code, f.reason))
+                        .unwrap_or_else(|| "connection closed".to_string());
+                    return Poll::Ready(Some(Err(Error::WebSocket(reason))));
+                }
+                // Ping/pong/binary/raw frames carry no events; keep polling.
+                Poll::Ready(Some(Ok(_))) => continue,
+                Poll::Ready(Some(Err(e))) => {
+                    self.terminated = true;
+                    return Poll::Ready(Some(Err(Error::WebSocket(e.to_string()))));
+                }
+            }
+        }
+    }
+}
+
+async fn connect<T>(client: &ProtectClient, endpoint: &str) -> Result<TypedWsStream<T>> {
+    let mut url = url::Url::parse(client.base_url())?;
+    let ws_scheme = match url.scheme() {
+        "https" | "wss" => "wss",
+        _ => "ws",
+    };
+    url.set_scheme(ws_scheme).map_err(|_| {
+        Error::WebSocket(format!("cannot derive ws url from {}", client.base_url()))
+    })?;
+
+    let ws_url = format!(
+        "{}/{}/{}",
+        url.as_str().trim_end_matches('/'),
+        PROTECT_BASE_PATH,
+        endpoint
+    );
+
+    let mut request = ws_url
+        .into_client_request()
+        .map_err(|e| Error::WebSocket(e.to_string()))?;
+    request
+        .headers_mut()
+        .insert("X-API-Key", client.api_key().parse()?);
+
+    let connector = if client.accepts_invalid_certs() {
+        let tls = native_tls::TlsConnector::builder()
+            .danger_accept_invalid_certs(true)
+            .danger_accept_invalid_hostnames(true)
+            .build()
+            .map_err(|e| Error::WebSocket(e.to_string()))?;
+        Some(Connector::NativeTls(tls))
+    } else {
+        None
+    };
+
+    let (inner, _response) = connect_async_tls_with_config(request, None, false, connector)
+        .await
+        .map_err(|e| Error::WebSocket(e.to_string()))?;
+
+    Ok(TypedWsStream {
+        inner,
+        terminated: false,
+        _marker: PhantomData,
+    })
+}
+
+impl ProtectClient {
+    /// Subscribe to live motion, smart-detection, doorbell, and connectivity
+    /// events.
+    /// Endpoint: WSS /proxy/protect/integration/v1/subscribe/events
+    ///
+    /// See the [module docs](self) for the reconnect idiom.
+    pub async fn subscribe_events(&self) -> Result<ProtectEventStream> {
+        connect(self, "subscribe/events").await
+    }
+
+    /// Subscribe to live partial device-state updates.
+    /// Endpoint: WSS /proxy/protect/integration/v1/subscribe/devices
+    ///
+    /// See the [module docs](self) for the reconnect idiom.
+    pub async fn subscribe_device_updates(&self) -> Result<DeviceUpdateStream> {
+        connect(self, "subscribe/devices").await
+    }
+}

--- a/src/protect/ws.rs
+++ b/src/protect/ws.rs
@@ -54,7 +54,9 @@ pub struct TypedWsStream<T> {
     // Set after a close frame or transport error; the stream then ends
     // instead of surfacing follow-up frames from the closing handshake.
     terminated: bool,
-    _marker: PhantomData<T>,
+    // fn() -> T keeps the stream Unpin/Send regardless of T, which is only
+    // ever produced by deserialization, never stored.
+    _marker: PhantomData<fn() -> T>,
 }
 
 impl<T> std::fmt::Debug for TypedWsStream<T> {
@@ -65,7 +67,7 @@ impl<T> std::fmt::Debug for TypedWsStream<T> {
 
 impl<T> Stream for TypedWsStream<T>
 where
-    T: for<'a> serde::Deserialize<'a> + Unpin,
+    T: for<'a> serde::Deserialize<'a>,
 {
     type Item = Result<WsMessage<T>>;
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -68,9 +68,11 @@ where
     let response = request.send().await?;
 
     if !response.status().is_success() {
-        return Err(crate::error::Error::Request(
-            response.error_for_status().unwrap_err(),
-        ));
+        // Preserve the error body — controllers return JSON describing the
+        // actual failure reason, which error_for_status() would discard.
+        let status = response.status().as_u16();
+        let body = response.text().await.unwrap_or_default();
+        return Err(crate::error::Error::Api { status, body });
     }
 
     let body = response.text().await?;

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,0 +1,99 @@
+//! Shared HTTP transport used by the UniFi Network and Protect clients.
+
+use crate::api::endpoint::{Endpoint, HttpMethod};
+use crate::error::Result;
+use reqwest::Client;
+
+/// Build a reqwest client with the crate's standard settings.
+///
+/// # Security Warning
+/// Passing `accept_invalid_certs = true` disables TLS certificate validation.
+/// Only use this for local consoles with self-signed certificates on trusted
+/// networks.
+pub(crate) fn build_http_client(accept_invalid_certs: bool, cookies: bool) -> Result<Client> {
+    let mut builder = Client::builder()
+        .user_agent("rustifi/1.0")
+        .connect_timeout(std::time::Duration::from_secs(30))
+        .timeout(std::time::Duration::from_secs(60));
+
+    if cookies {
+        let cookie_store = std::sync::Arc::new(reqwest::cookie::Jar::default());
+        builder = builder.cookie_store(true).cookie_provider(cookie_store);
+    }
+
+    if accept_invalid_certs {
+        builder = builder
+            .danger_accept_invalid_certs(true)
+            .danger_accept_invalid_hostnames(true);
+    }
+
+    Ok(builder.build()?)
+}
+
+/// Execute an [`Endpoint`] request against `{url_prefix}/{path}` and
+/// deserialize the JSON response.
+///
+/// `url_prefix` is the caller-computed base (e.g. `https://host/api/v1` or the
+/// remote connector form) without a trailing slash.
+pub(crate) async fn execute_endpoint<E>(
+    http: &Client,
+    url_prefix: &str,
+    api_key: Option<&str>,
+    endpoint: &E,
+) -> Result<E::Response>
+where
+    E: Endpoint,
+    E::Response: for<'a> serde::Deserialize<'a>,
+{
+    let url = format!("{}/{}", url_prefix, endpoint.build_path());
+
+    let mut headers = reqwest::header::HeaderMap::new();
+    if let Some(api_key) = api_key {
+        headers.insert("X-API-Key", api_key.parse()?);
+    }
+
+    let mut request = http.request(E::METHOD.into(), &url).headers(headers);
+
+    // Append query parameters using reqwest's query() for proper URL encoding
+    let params = endpoint.query_params();
+    if !params.is_empty() {
+        request = request.query(&params);
+    }
+
+    // Add JSON body for POST/PUT/PATCH methods
+    if let Some(body) = endpoint.request_body()? {
+        request = request.json(&body);
+    }
+
+    let response = request.send().await?;
+
+    if !response.status().is_success() {
+        return Err(crate::error::Error::Request(
+            response.error_for_status().unwrap_err(),
+        ));
+    }
+
+    let body = response.text().await?;
+    // Some endpoints (e.g. DELETE) return an empty body; deserialize it as null
+    // so responses typed as Option<_> or () succeed.
+    let effective_body = if body.trim().is_empty() {
+        "null"
+    } else {
+        &body
+    };
+    let response_data = serde_json::from_str::<E::Response>(effective_body)
+        .map_err(|e| crate::error::Error::Parse(format!("{}\nResponse body: {}", e, body)))?;
+    Ok(response_data)
+}
+
+impl From<HttpMethod> for reqwest::Method {
+    fn from(method: HttpMethod) -> Self {
+        match method {
+            HttpMethod::Get => reqwest::Method::GET,
+            HttpMethod::Post => reqwest::Method::POST,
+            HttpMethod::Put => reqwest::Method::PUT,
+            HttpMethod::Patch => reqwest::Method::PATCH,
+            HttpMethod::Delete => reqwest::Method::DELETE,
+        }
+    }
+}

--- a/tests/device_tests.rs
+++ b/tests/device_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "unifi")]
+
 use rustifi::models::{Device, DeviceType};
 use serde_json::json;
 

--- a/tests/pagination_tests.rs
+++ b/tests/pagination_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "unifi")]
+
 use rustifi::api::clients::GetClients;
 use rustifi::api::devices::GetDevices;
 use rustifi::api::Endpoint;

--- a/tests/protect_client.rs
+++ b/tests/protect_client.rs
@@ -136,17 +136,44 @@ async fn test_delete_rtsps_stream_query_params_and_empty_body() {
 }
 
 #[tokio::test]
-async fn test_error_status_maps_to_request_error() {
+async fn test_error_status_preserves_body() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
         .and(path("/proxy/protect/integration/v1/cameras/nope"))
-        .respond_with(ResponseTemplate::new(404))
+        .respond_with(
+            ResponseTemplate::new(404).set_body_json(json!({ "error": "camera not found" })),
+        )
         .mount(&server)
         .await;
 
     let err = client_for(&server).await.camera("nope").await.unwrap_err();
-    assert!(matches!(err, rustifi::Error::Request(_)));
+    match err {
+        rustifi::Error::Api { status, body } => {
+            assert_eq!(status, 404);
+            assert!(body.contains("camera not found"));
+        }
+        other => panic!("expected Api error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_resource_ids_are_path_encoded() {
+    let server = MockServer::start().await;
+
+    // An ID containing a slash must be encoded into a single path segment,
+    // not allowed to change the route.
+    Mock::given(method("GET"))
+        .and(path("/proxy/protect/integration/v1/cameras/a%2Fb"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "a/b", "modelKey": "camera", "state": "CONNECTED", "name": "Weird"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let camera = client_for(&server).await.camera("a/b").await.unwrap();
+    assert_eq!(camera.name, "Weird");
 }
 
 #[tokio::test]

--- a/tests/protect_client.rs
+++ b/tests/protect_client.rs
@@ -1,0 +1,166 @@
+#![cfg(feature = "protect")]
+
+use rustifi::protect::models::{CameraPatch, RtspsQuality};
+use rustifi::protect::ProtectClient;
+use serde_json::json;
+use wiremock::matchers::{body_json, header, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+async fn client_for(server: &MockServer) -> ProtectClient {
+    ProtectClient::new(server.uri(), "test-api-key").unwrap()
+}
+
+#[tokio::test]
+async fn test_cameras_bare_array_and_api_key_header() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/proxy/protect/integration/v1/cameras"))
+        .and(header("X-API-Key", "test-api-key"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            { "id": "cam1", "modelKey": "camera", "state": "CONNECTED", "name": "Front" },
+            { "id": "cam2", "modelKey": "camera", "state": "DISCONNECTED", "name": "Back" }
+        ])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let cameras = client_for(&server).await.cameras().await.unwrap();
+    assert_eq!(cameras.len(), 2);
+    assert_eq!(cameras[0].id, "cam1");
+    assert_eq!(cameras[1].name, "Back");
+}
+
+#[tokio::test]
+async fn test_patch_camera_sends_only_set_fields() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PATCH"))
+        .and(path("/proxy/protect/integration/v1/cameras/cam1"))
+        .and(header("X-API-Key", "test-api-key"))
+        .and(body_json(json!({ "name": "Renamed", "micVolume": 42 })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "cam1", "modelKey": "camera", "state": "CONNECTED", "name": "Renamed",
+            "micVolume": 42
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let patch = CameraPatch {
+        name: Some("Renamed".to_string()),
+        mic_volume: Some(42),
+        ..Default::default()
+    };
+    let camera = client_for(&server)
+        .await
+        .patch_camera("cam1", patch)
+        .await
+        .unwrap();
+    assert_eq!(camera.name, "Renamed");
+    assert_eq!(camera.mic_volume, Some(42));
+}
+
+#[tokio::test]
+async fn test_snapshot_returns_binary_bytes() {
+    let server = MockServer::start().await;
+    // Not valid JSON and not valid UTF-8 — must round-trip untouched.
+    let jpeg_bytes: Vec<u8> = vec![0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46];
+
+    Mock::given(method("GET"))
+        .and(path("/proxy/protect/integration/v1/cameras/cam1/snapshot"))
+        .and(query_param("highQuality", "true"))
+        .and(header("X-API-Key", "test-api-key"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(jpeg_bytes.clone())
+                .insert_header("content-type", "image/jpeg"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let bytes = client_for(&server)
+        .await
+        .snapshot("cam1", true)
+        .await
+        .unwrap();
+    assert_eq!(bytes, jpeg_bytes);
+}
+
+#[tokio::test]
+async fn test_create_rtsps_stream_body_and_response() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(
+            "/proxy/protect/integration/v1/cameras/cam1/rtsps-stream",
+        ))
+        .and(body_json(json!({ "qualities": ["high", "low"] })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "high": "rtsps://10.0.0.1:7441/aaaa",
+            "low": "rtsps://10.0.0.1:7441/bbbb"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let streams = client_for(&server)
+        .await
+        .create_rtsps_streams("cam1", vec![RtspsQuality::High, RtspsQuality::Low])
+        .await
+        .unwrap();
+    assert_eq!(streams.high.as_deref(), Some("rtsps://10.0.0.1:7441/aaaa"));
+    assert_eq!(streams.medium, None);
+}
+
+#[tokio::test]
+async fn test_delete_rtsps_stream_query_params_and_empty_body() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path(
+            "/proxy/protect/integration/v1/cameras/cam1/rtsps-stream",
+        ))
+        .and(query_param("qualities", "high"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    client_for(&server)
+        .await
+        .delete_rtsps_streams("cam1", vec![RtspsQuality::High])
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_error_status_maps_to_request_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/proxy/protect/integration/v1/cameras/nope"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let err = client_for(&server).await.camera("nope").await.unwrap_err();
+    assert!(matches!(err, rustifi::Error::Request(_)));
+}
+
+#[tokio::test]
+async fn test_meta_info() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/proxy/protect/integration/v1/meta/info"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "applicationVersion": "6.2.88" })),
+        )
+        .mount(&server)
+        .await;
+
+    let info = client_for(&server).await.meta_info().await.unwrap();
+    assert_eq!(info.application_version, "6.2.88");
+}

--- a/tests/protect_events.rs
+++ b/tests/protect_events.rs
@@ -1,0 +1,148 @@
+#![cfg(feature = "protect")]
+
+use rustifi::protect::models::{
+    DeviceUpdate, ModelKey, ProtectEvent, ProtectEventType, SmartDetectType, WsAction, WsMessage,
+};
+use serde_json::json;
+
+#[test]
+fn test_smart_detect_add_frame() {
+    let json_data = json!({
+        "type": "add",
+        "item": {
+            "id": "68386a43006bf603e4002b3d",
+            "modelKey": "event",
+            "type": "smartDetectZone",
+            "start": 1748517571853i64,
+            "device": "61ddb03ba0a70603e4004fab",
+            "smartDetectTypes": ["person"]
+        }
+    });
+
+    let msg: WsMessage<ProtectEvent> = serde_json::from_value(json_data).unwrap();
+    assert_eq!(msg.action, WsAction::Add);
+    assert_eq!(msg.item.model_key, ModelKey::Event);
+    assert_eq!(msg.item.event_type, ProtectEventType::SmartDetectZone);
+    assert_eq!(msg.item.start, 1748517571853);
+    assert_eq!(msg.item.end, None);
+    assert_eq!(msg.item.device, "61ddb03ba0a70603e4004fab");
+    assert_eq!(msg.item.smart_detect_types, vec![SmartDetectType::Person]);
+}
+
+#[test]
+fn test_smart_detect_update_frame_with_end() {
+    let json_data = json!({
+        "type": "update",
+        "item": {
+            "id": "68386a43006bf603e4002b3d",
+            "modelKey": "event",
+            "type": "smartDetectZone",
+            "start": 1748517571853i64,
+            "end": 1748517581453i64,
+            "device": "61ddb03ba0a70603e4004fab",
+            "smartDetectTypes": ["face", "person"]
+        }
+    });
+
+    let msg: WsMessage<ProtectEvent> = serde_json::from_value(json_data).unwrap();
+    assert_eq!(msg.action, WsAction::Update);
+    assert_eq!(msg.item.end, Some(1748517581453));
+    assert_eq!(
+        msg.item.smart_detect_types,
+        vec![SmartDetectType::Face, SmartDetectType::Person]
+    );
+}
+
+#[test]
+fn test_motion_event_frame() {
+    let json_data = json!({
+        "type": "add",
+        "item": {
+            "id": "68386a43006bf603e4002b3e",
+            "modelKey": "event",
+            "type": "motion",
+            "start": 1748517571853i64,
+            "device": "61ddb03ba0a70603e4004fab"
+        }
+    });
+
+    let msg: WsMessage<ProtectEvent> = serde_json::from_value(json_data).unwrap();
+    assert_eq!(msg.item.event_type, ProtectEventType::Motion);
+    assert!(msg.item.smart_detect_types.is_empty());
+}
+
+#[test]
+fn test_doorbell_ring_frame() {
+    let json_data = json!({
+        "type": "add",
+        "item": {
+            "id": "68386a43006bf603e4002b3f",
+            "modelKey": "event",
+            "type": "doorbell",
+            "start": 1748517571853i64,
+            "device": "61ddb03ba0a70603e4004fab"
+        }
+    });
+
+    let msg: WsMessage<ProtectEvent> = serde_json::from_value(json_data).unwrap();
+    assert_eq!(msg.item.event_type, ProtectEventType::Doorbell);
+}
+
+#[test]
+fn test_unknown_event_and_detect_types_tolerated() {
+    let json_data = json!({
+        "type": "add",
+        "item": {
+            "id": "abc",
+            "modelKey": "event",
+            "type": "someFutureEventType",
+            "start": 1i64,
+            "device": "dev1",
+            "smartDetectTypes": ["hoverboard", "person"]
+        }
+    });
+
+    let msg: WsMessage<ProtectEvent> = serde_json::from_value(json_data).unwrap();
+    assert_eq!(msg.item.event_type, ProtectEventType::Unknown);
+    assert_eq!(
+        msg.item.smart_detect_types,
+        vec![SmartDetectType::Unknown, SmartDetectType::Person]
+    );
+}
+
+#[test]
+fn test_unknown_ws_action_tolerated() {
+    let json_data = json!({
+        "type": "somethingElse",
+        "item": {
+            "id": "abc",
+            "modelKey": "event",
+            "type": "motion",
+            "start": 1i64,
+            "device": "dev1"
+        }
+    });
+
+    let msg: WsMessage<ProtectEvent> = serde_json::from_value(json_data).unwrap();
+    assert_eq!(msg.action, WsAction::Unknown);
+}
+
+#[test]
+fn test_device_update_frame() {
+    let json_data = json!({
+        "type": "update",
+        "item": {
+            "id": "61ddb03ba0a70603e4004fab",
+            "modelKey": "camera",
+            "state": "CONNECTED",
+            "isMicEnabled": false
+        }
+    });
+
+    let msg: WsMessage<DeviceUpdate> = serde_json::from_value(json_data).unwrap();
+    assert_eq!(msg.action, WsAction::Update);
+    assert_eq!(msg.item.id, "61ddb03ba0a70603e4004fab");
+    assert_eq!(msg.item.model_key, ModelKey::Camera);
+    assert_eq!(msg.item.fields.get("isMicEnabled"), Some(&json!(false)));
+    assert_eq!(msg.item.fields.get("state"), Some(&json!("CONNECTED")));
+}

--- a/tests/protect_types.rs
+++ b/tests/protect_types.rs
@@ -1,0 +1,248 @@
+#![cfg(feature = "protect")]
+
+use rustifi::protect::models::{
+    Camera, CameraPatch, Chime, Light, MetaInfo, ModelKey, Nvr, ProtectDeviceState, RtspsQuality,
+    RtspsStreams, Sensor, Viewer,
+};
+use serde_json::json;
+
+#[test]
+fn test_camera_deserialization() {
+    let json_data = json!({
+        "id": "61ddb03ba0a70603e4004fab",
+        "modelKey": "camera",
+        "state": "CONNECTED",
+        "name": "Front Door",
+        "mac": "74ACB9000000",
+        "model": "UVC G4 Doorbell",
+        "type": "UVC G4 Doorbell",
+        "firmwareVersion": "4.71.42",
+        "isMicEnabled": true,
+        "micVolume": 100,
+        "videoMode": "default",
+        "hdrType": "auto",
+        "osdSettings": {
+            "isNameEnabled": false,
+            "isDateEnabled": false,
+            "isLogoEnabled": true,
+            "isDebugEnabled": false
+        },
+        "ledSettings": { "isEnabled": true },
+        "lcdMessage": { "type": "LEAVE_PACKAGE_AT_DOOR", "text": "" },
+        "smartDetectSettings": {
+            "objectTypes": ["person", "vehicle"],
+            "autoTrackingObjectTypes": [],
+            "audioTypes": ["alrmSmoke"]
+        },
+        "recordingSettings": {
+            "mode": "always",
+            "prePaddingSecs": 3,
+            "postPaddingSecs": 3
+        },
+        "featureFlags": {
+            "hasHdr": true,
+            "hasMic": true,
+            "hasLedStatus": true,
+            "smartDetectTypes": ["person", "vehicle"],
+            "videoModes": ["default"],
+            "isPtz": false
+        }
+    });
+
+    let camera: Camera = serde_json::from_value(json_data).unwrap();
+    assert_eq!(camera.id, "61ddb03ba0a70603e4004fab");
+    assert_eq!(camera.model_key, ModelKey::Camera);
+    assert_eq!(camera.state, ProtectDeviceState::Connected);
+    assert_eq!(camera.name, "Front Door");
+    assert_eq!(camera.mac.unwrap().as_str(), "74ACB9000000");
+    assert_eq!(camera.mic_volume, Some(100));
+    assert_eq!(camera.osd_settings.unwrap().is_logo_enabled, Some(true));
+    assert_eq!(
+        camera.smart_detect_settings.unwrap().object_types.unwrap(),
+        vec!["person", "vehicle"]
+    );
+    assert!(camera.feature_flags.unwrap().has_hdr.unwrap());
+}
+
+#[test]
+fn test_camera_minimal_and_unknown_fields() {
+    // Only guaranteed fields plus an unknown field from a future release
+    let json_data = json!({
+        "id": "abc123",
+        "modelKey": "camera",
+        "state": "CONNECTED",
+        "name": "Minimal Cam",
+        "someFutureField": { "nested": true }
+    });
+
+    let camera: Camera = serde_json::from_value(json_data).unwrap();
+    assert_eq!(camera.id, "abc123");
+    assert_eq!(camera.mac, None);
+    assert_eq!(camera.osd_settings, None);
+}
+
+#[test]
+fn test_unknown_enum_variants_tolerated() {
+    let json_data = json!({
+        "id": "abc123",
+        "modelKey": "somethingNew",
+        "state": "SOMETHING_NEW",
+        "name": "Future Device"
+    });
+
+    let camera: Camera = serde_json::from_value(json_data).unwrap();
+    assert_eq!(camera.model_key, ModelKey::Unknown);
+    assert_eq!(camera.state, ProtectDeviceState::Unknown);
+}
+
+#[test]
+fn test_camera_patch_skips_none_fields() {
+    let patch = CameraPatch {
+        name: Some("New Name".to_string()),
+        mic_volume: Some(50),
+        ..Default::default()
+    };
+
+    let value = serde_json::to_value(&patch).unwrap();
+    assert_eq!(value, json!({ "name": "New Name", "micVolume": 50 }));
+}
+
+#[test]
+fn test_rtsps_streams_deserialization() {
+    let json_data = json!({
+        "high": "rtsps://192.168.1.1:7441/abcd1234",
+        "medium": null,
+        "low": "rtsps://192.168.1.1:7441/wxyz9876"
+    });
+
+    let streams: RtspsStreams = serde_json::from_value(json_data).unwrap();
+    assert_eq!(
+        streams.high.as_deref(),
+        Some("rtsps://192.168.1.1:7441/abcd1234")
+    );
+    assert_eq!(streams.medium, None);
+    assert_eq!(streams.package, None);
+}
+
+#[test]
+fn test_rtsps_quality_serialization() {
+    assert_eq!(
+        serde_json::to_value(RtspsQuality::High).unwrap(),
+        json!("high")
+    );
+    assert_eq!(RtspsQuality::Package.as_str(), "package");
+}
+
+#[test]
+fn test_light_deserialization() {
+    let json_data = json!({
+        "id": "5f9b1c000000000000000000",
+        "modelKey": "light",
+        "state": "CONNECTED",
+        "name": "Backyard Floodlight",
+        "isLightOn": false,
+        "isPirMotionDetected": false,
+        "lightModeSettings": { "mode": "motion", "enableAt": "fulltime" },
+        "lightDeviceSettings": {
+            "isIndicatorEnabled": true,
+            "ledLevel": 4,
+            "pirDuration": 15000,
+            "pirSensitivity": 50
+        }
+    });
+
+    let light: Light = serde_json::from_value(json_data).unwrap();
+    assert_eq!(light.name, "Backyard Floodlight");
+    assert_eq!(light.is_light_on, Some(false));
+    assert_eq!(
+        light.light_mode_settings.unwrap().mode.as_deref(),
+        Some("motion")
+    );
+    assert_eq!(light.light_device_settings.unwrap().led_level, Some(4));
+}
+
+#[test]
+fn test_sensor_deserialization() {
+    let json_data = json!({
+        "id": "5f9b2d000000000000000000",
+        "modelKey": "sensor",
+        "state": "CONNECTED",
+        "name": "Garage Door",
+        "mountType": "door",
+        "isOpened": false,
+        "batteryStatus": { "percentage": 87, "isLow": false },
+        "stats": {
+            "light": { "value": 12.0, "status": "neutral" },
+            "temperature": { "value": 21.5, "status": "neutral" },
+            "humidity": { "value": 40.0, "status": "neutral" }
+        },
+        "motionSettings": { "isEnabled": true, "sensitivity": 80 }
+    });
+
+    let sensor: Sensor = serde_json::from_value(json_data).unwrap();
+    assert_eq!(sensor.mount_type.as_deref(), Some("door"));
+    assert_eq!(sensor.battery_status.unwrap().percentage, Some(87));
+    let stats = sensor.stats.unwrap();
+    assert_eq!(stats.temperature.unwrap().value, Some(21.5));
+    assert_eq!(sensor.motion_settings.unwrap().sensitivity, Some(80));
+}
+
+#[test]
+fn test_chime_deserialization() {
+    let json_data = json!({
+        "id": "5f9b3e000000000000000000",
+        "modelKey": "chime",
+        "state": "CONNECTED",
+        "name": "Hallway Chime",
+        "volume": 80,
+        "cameraIds": ["61ddb03ba0a70603e4004fab"],
+        "ringSettings": [
+            { "cameraId": "61ddb03ba0a70603e4004fab", "repeatTimes": 1, "trackNo": 1, "volume": 80 }
+        ]
+    });
+
+    let chime: Chime = serde_json::from_value(json_data).unwrap();
+    assert_eq!(chime.volume, Some(80));
+    assert_eq!(chime.camera_ids.unwrap().len(), 1);
+    assert_eq!(chime.ring_settings.unwrap()[0].repeat_times, Some(1));
+}
+
+#[test]
+fn test_viewer_deserialization() {
+    let json_data = json!({
+        "id": "5f9b4f000000000000000000",
+        "modelKey": "viewer",
+        "state": "DISCONNECTED",
+        "name": "Lobby Screen",
+        "liveview": "5f9b5a000000000000000000"
+    });
+
+    let viewer: Viewer = serde_json::from_value(json_data).unwrap();
+    assert_eq!(viewer.state, ProtectDeviceState::Disconnected);
+    assert_eq!(viewer.liveview.as_deref(), Some("5f9b5a000000000000000000"));
+}
+
+#[test]
+fn test_nvr_deserialization() {
+    let json_data = json!({
+        "id": "5f9b6b000000000000000000",
+        "modelKey": "nvr",
+        "name": "Dream Machine Pro",
+        "mac": "74ACB9111111",
+        "version": "5.3.41",
+        "uptime": 123456789i64,
+        "hardwarePlatform": "al324"
+    });
+
+    let nvr: Nvr = serde_json::from_value(json_data).unwrap();
+    assert_eq!(nvr.name, "Dream Machine Pro");
+    assert_eq!(nvr.version.as_deref(), Some("5.3.41"));
+    assert_eq!(nvr.uptime, Some(123456789));
+}
+
+#[test]
+fn test_meta_info_deserialization() {
+    let json_data = json!({ "applicationVersion": "6.2.88" });
+    let info: MetaInfo = serde_json::from_value(json_data).unwrap();
+    assert_eq!(info.application_version, "6.2.88");
+}

--- a/tests/protect_ws.rs
+++ b/tests/protect_ws.rs
@@ -1,0 +1,95 @@
+#![cfg(feature = "protect")]
+
+use futures::{SinkExt, StreamExt};
+use rustifi::protect::models::{ProtectEventType, WsAction};
+use rustifi::protect::ProtectClient;
+use rustifi::Error;
+use tokio_tungstenite::tungstenite::Message;
+
+/// Spawn a WebSocket server on an ephemeral port that accepts one connection,
+/// sends the given frames, and then closes.
+async fn spawn_ws_server(frames: Vec<Message>) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+        for frame in frames {
+            ws.send(frame).await.unwrap();
+        }
+        let _ = ws.close(None).await;
+    });
+
+    format!("http://{}", addr)
+}
+
+fn event_frame(event_type: &str) -> Message {
+    Message::Text(
+        format!(
+            r#"{{"type":"add","item":{{"id":"e1","modelKey":"event","type":"{}","start":1748517571853,"device":"cam1","smartDetectTypes":[]}}}}"#,
+            event_type
+        )
+        .into(),
+    )
+}
+
+#[tokio::test]
+async fn test_event_stream_decodes_text_frames() {
+    let base_url =
+        spawn_ws_server(vec![event_frame("motion"), event_frame("smartDetectZone")]).await;
+
+    let client = ProtectClient::new(base_url, "test-key").unwrap();
+    let mut stream = client.subscribe_events().await.unwrap();
+
+    let first = stream.next().await.unwrap().unwrap();
+    assert_eq!(first.action, WsAction::Add);
+    assert_eq!(first.item.event_type, ProtectEventType::Motion);
+
+    let second = stream.next().await.unwrap().unwrap();
+    assert_eq!(second.item.event_type, ProtectEventType::SmartDetectZone);
+}
+
+#[tokio::test]
+async fn test_event_stream_skips_pings_and_ends_on_close() {
+    let base_url = spawn_ws_server(vec![
+        Message::Ping(vec![1, 2, 3].into()),
+        event_frame("doorbell"),
+    ])
+    .await;
+
+    let client = ProtectClient::new(base_url, "test-key").unwrap();
+    let mut stream = client.subscribe_events().await.unwrap();
+
+    // The ping must be skipped, yielding the doorbell event first.
+    let first = stream.next().await.unwrap().unwrap();
+    assert_eq!(first.item.event_type, ProtectEventType::Doorbell);
+
+    // Server close: a WebSocket error item, then the stream ends.
+    match stream.next().await {
+        Some(Err(Error::WebSocket(_))) | None => {}
+        other => panic!("expected close or end of stream, got {:?}", other.is_some()),
+    }
+    assert!(stream.next().await.is_none());
+}
+
+#[tokio::test]
+async fn test_event_stream_surfaces_parse_errors_and_continues() {
+    let base_url = spawn_ws_server(vec![
+        Message::Text("this is not json".to_string().into()),
+        event_frame("motion"),
+    ])
+    .await;
+
+    let client = ProtectClient::new(base_url, "test-key").unwrap();
+    let mut stream = client.subscribe_events().await.unwrap();
+
+    match stream.next().await {
+        Some(Err(Error::Parse(_))) => {}
+        other => panic!("expected parse error, got ok={:?}", other.is_some()),
+    }
+
+    // The stream must survive a malformed frame.
+    let next = stream.next().await.unwrap().unwrap();
+    assert_eq!(next.item.event_type, ProtectEventType::Motion);
+}

--- a/tests/response_tests.rs
+++ b/tests/response_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "unifi")]
+
 use rustifi::response::{ApiResponse, PaginatedResponse};
 use serde::Deserialize;
 use serde_json::json;

--- a/tests/stats_tests.rs
+++ b/tests/stats_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "unifi")]
+
 use rustifi::models::{AccessType, Client, ClientAccess, ClientType};
 use rustifi::stats::{aggregate_clients_by_device, get_device_client_stats, DeviceClientStats};
 

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "unifi")]
+
 use rustifi::models::{IpAddress, MacAddress};
 use serde_json::json;
 use std::net::Ipv4Addr;

--- a/tests/types_extended.rs
+++ b/tests/types_extended.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "unifi")]
+
 use rustifi::models::{AccessType, Client, ClientType};
 use serde_json::json;
 


### PR DESCRIPTION
## Summary

Adds support for the official **UniFi Protect Integration API** (Protect >= 5.3) behind a new opt-in `protect` cargo feature, with the existing Network API moving behind a `unifi` feature that remains in `default`.

- **New `ProtectClient`** targeting `/proxy/protect/integration/v1` with the same `X-API-Key` auth as the Network client: cameras (list/get/patch), binary JPEG snapshots, RTSPS stream get/create/delete, lights, sensors, chimes, viewers, NVR, and `meta/info`.
- **Live WebSocket subscriptions** — `subscribe_events()` and `subscribe_device_updates()` return typed `futures::Stream`s over `{"type", "item"}` envelopes. No auto-reconnect by design (the API has no replay cursor); the reconnect idiom is documented.
- **Shared HTTP transport** (`src/transport.rs`) extracted from `UnifiClient` so both clients share request/deserialize behavior.
- **First `[features]` table**: `default = ["unifi"]`; shared core (Error, Endpoint trait, common models) stays ungated. CI now tests the feature matrix.
- **BREAKING**: `Error` is now `#[non_exhaustive]` and gained a `WebSocket(String)` variant (declared via `BREAKING CHANGE` footer → release-plz will cut 2.0.0).
- **Tests**: serde round-trips from captured payloads, wiremock HTTP mocks (headers, PATCH bodies, binary snapshot bytes), and a local tungstenite server for stream behavior.
- New `examples/protect-events/` package; README Protect section.

## Needs live-console verification (non-blocking)

- `GET /nvrs` response shape (modeled as a single object)
- RTSPS DELETE param placement (implemented as `?qualities=` query params)

## Test plan

- [x] `cargo build` / `test` / `clippy` / `fmt --check` across default, `--no-default-features`, `--no-default-features --features protect`, `--all-features`
- [x] `cargo test --doc --all-features` (23 doctests)
- [x] `examples/protect-events` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional UniFi Protect Integration API support.
  * Added access to cameras, snapshots, RTSPS streams, lights, sensors, chimes, viewers, NVR information, and application metadata.
  * Added typed live event and device update subscriptions over WebSockets.
  * Added secure and local self-signed certificate connection options.
* **Documentation**
  * Added setup instructions, usage examples, Cargo feature guidance, and live event behavior details.
* **Testing**
  * Expanded coverage across supported feature combinations and Protect API functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->